### PR TITLE
fix(ssh): Bitwarden SSH agent を IdentityAgent で常用しシェル起動順依存を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ SSH 秘密鍵はディスクに置かず、Bitwarden Desktop アプリの内蔵 
   ```
   ~/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock
   ```
-- `fish/config.fish` がソケット存在時のみ `SSH_AUTH_SOCK` をそこへ向ける
+- `ssh/config`（`~/.ssh/config` に symlink）の `IdentityAgent` でこのソケットを常用する。接続時に解決されるため、シェルや Bitwarden の起動順に依存しない
 - 鍵の追加は SSH キー型アイテムとして登録（既存鍵はファイルからインポート、または新規生成）
 - git/ssh 利用には **アプリ起動 + vault アンロック** が必要
 

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -133,9 +133,5 @@ set -gx PATH $PATH /Users/roy/.lmstudio/bin
 # End of LM Studio CLI section
 
 # SSH 鍵は Bitwarden Desktop の SSH agent で管理する（秘密鍵をディスクに置かない）
-# アプリ起動時のみソケットが存在するので、その時だけ SSH_AUTH_SOCK を向ける
-set -l bw_ssh_sock ~/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock
-if test -S $bw_ssh_sock
-    set -gx SSH_AUTH_SOCK $bw_ssh_sock
-end
+# socket の指定は ~/.ssh/config の IdentityAgent に一本化（接続時解決でシェル起動順に依存しない）
 

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -129,6 +129,12 @@ create_symlink $BASE_DIR/jjconfig.toml ~/.config/jj/config.toml "jujutsu config"
 
 echo ""
 
+# SSH設定ファイル（Bitwarden SSH agent を IdentityAgent で常用）
+echo "🔑 Setting up SSH configuration..."
+create_symlink $BASE_DIR/ssh/config ~/.ssh/config "SSH config"
+
+echo ""
+
 # Claudeサンドボックスプロファイル
 echo "🔒 Setting up Claude sandbox profile..."
 create_symlink $BASE_DIR/claude/sandbox/claude-sandbox.sb ~/.claude/sandbox/claude-sandbox.sb "Claude sandbox profile"

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,5 @@
+# SSH 鍵は Bitwarden Desktop の SSH agent で管理する（秘密鍵をディスクに置かない）
+# 接続時に必ず Bitwarden の socket を使うので、シェル起動タイミングに依存しない
+# 利用には Bitwarden Desktop の起動 + vault アンロックが必要
+Host *
+    IdentityAgent ~/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock


### PR DESCRIPTION
## 背景

`jj git fetch` 時に `Permission denied (publickey)` が発生した。原因はシェルの `SSH_AUTH_SOCK` が macOS 標準 agent（launchd）を指したまま Bitwarden agent を見ていなかったこと。

従来の `config.fish` 方式はシェル起動時に socket が存在する場合のみ `SSH_AUTH_SOCK` を向けるため、**Bitwarden Desktop 起動より前に立ち上がったシェルでは効かない**（=今回の不具合）。

## 変更

socket 指定を `~/.ssh/config` の `IdentityAgent` に一本化。接続時に解決されるため、シェル/Bitwarden の起動順に依存しない。

- `ssh/config` 追加（`~/.ssh/config` へ symlink）
- `setup_fish.sh` に symlink 作成ステップを追加
- `config.fish` の `SSH_AUTH_SOCK` ブロックを削除（IdentityAgent に一本化）
- README の手順を更新

## 確認

`SSH_AUTH_SOCK` 未設定（launchd を指す状態）でも `ssh -T git@github.com` が認証成功することを確認済み。