### PR TITLE
feat(claude): statuslineを追加しhookのJSON出力エラーを修正

### DIFF
--- a/claude/hooks/block-dangerous-commands.sh
+++ b/claude/hooks/block-dangerous-commands.sh
@@ -3,7 +3,7 @@
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
-block_msg='{"decision":"block","reason":"mainへのpushはClaude内では実行禁止です。手動で実行してください。"}'
+block_msg='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"mainへのpushはClaude内では実行禁止です。手動で実行してください。"}}'
 
 # jj git push: 引数なし or -b main を拒否
 if echo "$command" | grep -qE 'jj git push.*-b\s+main|jj git push\s*(;|&&|\||$)'; then
@@ -17,4 +17,5 @@ if echo "$command" | grep -qE 'git push\s+\S+\s+main|git push\s*(;|&&|\||$)'; th
   exit 0
 fi
 
-echo '{"decision":"allow"}'
+# 出力なし = 許可
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,10 +16,7 @@
     ],
     "defaultMode": "bypassPermissions"
   },
-  "statusLine": {
-    "type": "command",
-    "command": "\"$HOME\"/.claude/statusline.sh"
-  },
+  "model": "claude-fable-5[1m]",
   "hooks": {
     "PreToolUse": [
       {
@@ -33,6 +30,10 @@
         ]
       }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "\"$HOME\"/.claude/statusline.sh"
   },
   "enabledPlugins": {
     "feature-dev@claude-plugins-official": true,
@@ -103,8 +104,7 @@
       "cld"
     ]
   },
-  "effortLevel": "medium",
+  "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true,
-  "remoteControlAtStartup": true,
-  "model": "claude-fable-5[1m]"
+  "remoteControlAtStartup": true
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -16,6 +16,10 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "\"$HOME\"/.claude/statusline.sh"
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -101,5 +105,6 @@
   },
   "effortLevel": "medium",
   "skipDangerousModePermissionPrompt": true,
-  "remoteControlAtStartup": true
+  "remoteControlAtStartup": true,
+  "model": "claude-fable-5[1m]"
 }

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -21,9 +21,14 @@ BAR="${FILL// /█}${PAD// /░}"
 
 MINS=$((DURATION_MS / 60000)); SECS=$(((DURATION_MS % 60000) / 1000))
 
-# jjはdetached HEADでブランチ名が空になるため短縮ハッシュにフォールバック
+# jjなら直近のブックマークと@の位置、gitならブランチ名(なければ短縮ハッシュ)
+# --ignore-working-copy: statusline実行で勝手にスナップショットさせない
 BRANCH=""
-if git -C "$DIR" rev-parse --git-dir > /dev/null 2>&1; then
+if jj -R "$DIR" --ignore-working-copy root > /dev/null 2>&1; then
+  BOOKMARK=$(jj -R "$DIR" --ignore-working-copy log -r 'heads(::@ & bookmarks())' --no-graph -T 'bookmarks' 2>/dev/null)
+  AT=$(jj -R "$DIR" --ignore-working-copy log -r @ --no-graph -T 'change_id.shortest(8)' 2>/dev/null)
+  BRANCH=" | 🔖 ${BOOKMARK:-(no bookmark)} @ $AT"
+elif git -C "$DIR" rev-parse --git-dir > /dev/null 2>&1; then
   NAME=$(git -C "$DIR" branch --show-current 2>/dev/null)
   [ -z "$NAME" ] && NAME=$(git -C "$DIR" rev-parse --short HEAD 2>/dev/null)
   [ -n "$NAME" ] && BRANCH=" | 🌿 $NAME"
@@ -37,7 +42,7 @@ LIMITS=""
 [ -n "$WEEK" ] && LIMITS="${LIMITS} | 7d: $(printf '%.0f' "$WEEK")%"
 
 COST_FMT=$(printf '$%.2f' "$COST")
-# 1行目: [モデル名] 📁 ディレクトリ名 | 🌿 ブランチ名(なければ短縮ハッシュ)
+# 1行目: [モデル名] 📁 ディレクトリ名 | 🔖 ブックマーク @ change-id (jj) / 🌿 ブランチ名 (git)
 echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
 # 2行目: コンテキストバー 使用率% | セッションコスト | 経過時間 | 5h/7dレート制限使用率
 echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s${LIMITS}"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Claude Code status line: 1行目=モデル/ディレクトリ/ブランチ、2行目=コンテキストバー/コスト/経過時間
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model.display_name')
+DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
+
+CYAN='\033[36m'; GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; RESET='\033[0m'
+
+# コンテキスト使用率で色分け
+if [ "$PCT" -ge 90 ]; then BAR_COLOR="$RED"
+elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$YELLOW"
+else BAR_COLOR="$GREEN"; fi
+
+FILLED=$((PCT / 10)); EMPTY=$((10 - FILLED))
+printf -v FILL "%${FILLED}s"; printf -v PAD "%${EMPTY}s"
+BAR="${FILL// /█}${PAD// /░}"
+
+MINS=$((DURATION_MS / 60000)); SECS=$(((DURATION_MS % 60000) / 1000))
+
+# jjはdetached HEADでブランチ名が空になるため短縮ハッシュにフォールバック
+BRANCH=""
+if git -C "$DIR" rev-parse --git-dir > /dev/null 2>&1; then
+  NAME=$(git -C "$DIR" branch --show-current 2>/dev/null)
+  [ -z "$NAME" ] && NAME=$(git -C "$DIR" rev-parse --short HEAD 2>/dev/null)
+  [ -n "$NAME" ] && BRANCH=" | 🌿 $NAME"
+fi
+
+COST_FMT=$(printf '$%.2f' "$COST")
+echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
+echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -37,5 +37,7 @@ LIMITS=""
 [ -n "$WEEK" ] && LIMITS="${LIMITS} | 7d: $(printf '%.0f' "$WEEK")%"
 
 COST_FMT=$(printf '$%.2f' "$COST")
+# 1行目: [モデル名] 📁 ディレクトリ名 | 🌿 ブランチ名(なければ短縮ハッシュ)
 echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
+# 2行目: コンテキストバー 使用率% | セッションコスト | 経過時間 | 5h/7dレート制限使用率
 echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s${LIMITS}"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -29,6 +29,13 @@ if git -C "$DIR" rev-parse --git-dir > /dev/null 2>&1; then
   [ -n "$NAME" ] && BRANCH=" | 🌿 $NAME"
 fi
 
+# レート制限はPro/Max限定かつ初回API応答後のみ存在するため、absent時は非表示
+FIVE_H=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+WEEK=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+LIMITS=""
+[ -n "$FIVE_H" ] && LIMITS=" | 5h: $(printf '%.0f' "$FIVE_H")%"
+[ -n "$WEEK" ] && LIMITS="${LIMITS} | 7d: $(printf '%.0f' "$WEEK")%"
+
 COST_FMT=$(printf '$%.2f' "$COST")
 echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
-echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s"
+echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s${LIMITS}"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -8,6 +8,10 @@ COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
 DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
 
+# effortは非対応モデルではabsent。あればモデル名に併記
+EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
+[ -n "$EFFORT" ] && MODEL="$MODEL:$EFFORT"
+
 CYAN='\033[36m'; GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; RESET='\033[0m'
 
 # コンテキスト使用率で色分け
@@ -34,15 +38,35 @@ elif git -C "$DIR" rev-parse --git-dir > /dev/null 2>&1; then
   [ -n "$NAME" ] && BRANCH=" | 🌿 $NAME"
 fi
 
+# セッションでの変更行数。両方0なら非表示
+ADDED=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
+REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
+LINES=""
+[ "$ADDED" -gt 0 ] || [ "$REMOVED" -gt 0 ] && LINES=" | ${GREEN}+${ADDED}${RESET} ${RED}-${REMOVED}${RESET}"
+
+# epoch秒を時刻表示に変換。date -rはmacOS/BSD、-dはLinux(WSL2)用
+fmt_epoch() {
+  date -r "$1" +"$2" 2>/dev/null || date -d "@$1" +"$2" 2>/dev/null
+}
+
 # レート制限はPro/Max限定かつ初回API応答後のみ存在するため、absent時は非表示
+# リセット時刻は5hなら時刻(HH:MM)、7dなら日付(M/D)で表示
 FIVE_H=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+FIVE_H_AT=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
 WEEK=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+WEEK_AT=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 LIMITS=""
-[ -n "$FIVE_H" ] && LIMITS=" | 5h: $(printf '%.0f' "$FIVE_H")%"
-[ -n "$WEEK" ] && LIMITS="${LIMITS} | 7d: $(printf '%.0f' "$WEEK")%"
+if [ -n "$FIVE_H" ]; then
+  LIMITS=" | 5h: $(printf '%.0f' "$FIVE_H")%"
+  [ -n "$FIVE_H_AT" ] && LIMITS="${LIMITS} (→$(fmt_epoch "$FIVE_H_AT" %H:%M))"
+fi
+if [ -n "$WEEK" ]; then
+  LIMITS="${LIMITS} | 7d: $(printf '%.0f' "$WEEK")%"
+  [ -n "$WEEK_AT" ] && LIMITS="${LIMITS} (→$(fmt_epoch "$WEEK_AT" %-m/%-d))"
+fi
 
 COST_FMT=$(printf '$%.2f' "$COST")
-# 1行目: [モデル名] 📁 ディレクトリ名 | 🔖 ブックマーク @ change-id (jj) / 🌿 ブランチ名 (git)
+# 1行目: [モデル名:effort] 📁 ディレクトリ名 | 🔖 ブックマーク @ change-id (jj) / 🌿 ブランチ名 (git)
 echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
-# 2行目: コンテキストバー 使用率% | セッションコスト | 経過時間 | 5h/7dレート制限使用率
-echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s${LIMITS}"
+# 2行目: コンテキストバー 使用率% | 変更行数 | セッションコスト | 経過時間 | 5h/7dレート制限使用率 (→リセット時刻)
+echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}%${LINES} | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s${LIMITS}"

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -138,6 +138,7 @@ echo ""
 # Claudeサンドボックスプロファイル
 echo "🔒 Setting up Claude sandbox profile..."
 create_symlink $BASE_DIR/claude/sandbox/claude-sandbox.sb ~/.claude/sandbox/claude-sandbox.sb "Claude sandbox profile"
+create_symlink $BASE_DIR/claude/statusline.sh ~/.claude/statusline.sh "Claude status line script"
 
 echo ""
 


### PR DESCRIPTION
## 概要

Claude Code のステータスラインを新設し、あわせて PreToolUse hook の JSON 出力エラーを修正した。

## 変更内容

### statusline 新設 (`claude/statusline.sh`)

2行構成で以下を常時表示する。

```
[Fable:medium] 📁 dotsfile | 🔖 claude-statusline* @ xszknkro
████░░░░░░ 42% | +156 -23 | $1.20 | ⏱️ 12m 34s | 5h: 24% (→14:40) | 7d: 41% (→6/15)
```

- 1行目: モデル名:effortレベル / ディレクトリ名 / VCS情報
  - jj リポジトリでは直近のブックマークと @ の change-id を表示（`--ignore-working-copy` で勝手なスナップショットを防止）
  - git のみの場合はブランチ名（detached なら短縮ハッシュ）
- 2行目: コンテキスト使用率バー（70%で黄、90%で赤）/ 変更行数 / セッションコスト / 経過時間 / 5h・7dレート制限使用率とリセット時刻
- レート制限などabsentになり得るフィールドは非表示にフォールバック
- リセット時刻の epoch 変換は `date -r`(macOS) / `date -d`(Linux/WSL2) 両対応

### hook 修正 (`claude/hooks/block-dangerous-commands.sh`)

- 許可時に `{"decision":"allow"}` を出力していたが、PreToolUse のスキーマに `"allow"` は存在せず毎回 validation エラーになっていた。許可時は無出力 + exit 0 に修正
- block 時の出力も deprecated な `decision/reason` から `hookSpecificOutput.permissionDecision` 形式に更新

### その他

- `claude/settings.json`: statusLine 設定・model 指定・effortLevel 変更
- `scripts/build_env/setup_fish.sh`: statusline.sh のシンボリックリンク作成を追加

## テスト

- モック JSON 入力で全項目あり / 最小項目（リポジトリ外・レート制限なし）の両方を確認
- hook は許可ケース（無出力）と block ケース（deny JSON）を確認