### PR TITLE
feat(wsl): WSL2対応とBitwarden SSH agentブリッジを追加

### DIFF
--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -45,7 +45,8 @@
     "cloud-sql-proxy@latest",
     "grpcurl@latest",
     "temporal-cli@latest",
-    "bitwarden-cli@latest"
+    "bitwarden-cli@latest",
+    "socat@latest"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",

--- a/fish/abbreviations.fish
+++ b/fish/abbreviations.fish
@@ -55,7 +55,12 @@ abbr gc 'ghq-cd'  # ghq cd shortcut
 # OS specific
 switch (uname)
     case Linux
-        abbr open 'xdg-open'
+        if string match -q '*microsoft*' (uname -r)
+            # WSL2: explorer.exe ならWindows側のブラウザ/エクスプローラーで開ける
+            abbr open 'explorer.exe'
+        else
+            abbr open 'xdg-open'
+        end
     case Darwin
         # Mac用の設定（必要に応じて追加）
 end

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -128,9 +128,10 @@ if not string match -q -- $GCLOUD_PATH $PATH
 end
 # gcloud end
 
-# Added by LM Studio CLI (lms)
-set -gx PATH $PATH /Users/roy/.lmstudio/bin
-# End of LM Studio CLI section
+# LM Studio CLI (lms)
+if test -d "$HOME/.lmstudio/bin"
+    fish_add_path --append $HOME/.lmstudio/bin
+end
 
 # SSH 鍵は Bitwarden Desktop の SSH agent で管理する（秘密鍵をディスクに置かない）
 # socket の指定は ~/.ssh/config の IdentityAgent に一本化（接続時解決でシェル起動順に依存しない）

--- a/fish/fzf.fish
+++ b/fish/fzf.fish
@@ -5,20 +5,9 @@
 if command -q fzf
     
     # fzf fish integration
-    # Ubuntu/Debianの場合の標準的なパス
-    if test -f /usr/share/doc/fzf/examples/key-bindings.fish
-        source /usr/share/doc/fzf/examples/key-bindings.fish
-    end
-    
-    # fzf completions
-    if test -f /usr/share/doc/fzf/examples/completion.fish
-        source /usr/share/doc/fzf/examples/completion.fish
-    end
-    
-    # Homebrewの場合（Macなど）
-    if test -f /opt/homebrew/opt/fzf/shell/key-bindings.fish
-        source /opt/homebrew/opt/fzf/shell/key-bindings.fish
-    end
+    # fzf 0.48+ はインストール元（devbox/apt/Homebrew）に関わらず
+    # key bindings と補完を自前で生成できる
+    fzf --fish | source
     
     # fzf設定
     set -gx FZF_DEFAULT_OPTS '

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -133,12 +133,24 @@ echo ""
 echo "🔑 Setting up SSH configuration..."
 create_symlink $BASE_DIR/ssh/config ~/.ssh/config "SSH config"
 
+# WSL2のみ: Bitwarden SSH agent ブリッジ（Windows named pipe -> unix socket）
+if string match -q '*microsoft*' (uname -r)
+    echo "🪟 Setting up Bitwarden SSH agent bridge (WSL2)..."
+    create_symlink $BASE_DIR/scripts/wsl/bitwarden-ssh-agent.service ~/.config/systemd/user/bitwarden-ssh-agent.service "Bitwarden SSH agent bridge"
+    systemctl --user daemon-reload
+    systemctl --user enable --now bitwarden-ssh-agent.service
+end
+
 echo ""
 
-# Claudeサンドボックスプロファイル
-echo "🔒 Setting up Claude sandbox profile..."
-create_symlink $BASE_DIR/claude/sandbox/claude-sandbox.sb ~/.claude/sandbox/claude-sandbox.sb "Claude sandbox profile"
+# Claude Code 設定（settings.json が参照する hooks/statusline も含めて一式リンクする）
+echo "🤖 Setting up Claude Code configuration..."
+create_symlink $BASE_DIR/claude/settings.json ~/.claude/settings.json "Claude settings"
 create_symlink $BASE_DIR/claude/statusline.sh ~/.claude/statusline.sh "Claude status line script"
+set CLAUDE_ITEMS agents commands hooks rules skills sandbox
+for item in $CLAUDE_ITEMS
+    create_symlink $BASE_DIR/claude/$item ~/.claude/$item "Claude $item"
+end
 
 echo ""
 

--- a/scripts/wsl/bitwarden-ssh-agent.service
+++ b/scripts/wsl/bitwarden-ssh-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bitwarden SSH agent bridge (Windows named pipe -> WSL unix socket)
+
+[Service]
+# Windows側 Bitwarden Desktop の SSH agent (named pipe) を WSL の unix socket に中継する
+# npiperelay.exe の実行には WSL interop (binfmt) が必要
+ExecStart=%h/.local/share/devbox/global/default/.devbox/nix/profile/default/bin/socat UNIX-LISTEN:%h/.bitwarden-ssh-agent.sock,fork,unlink-early,umask=177 EXEC:"/mnt/c/Users/roy/bin/npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/scripts/wsl/wsl-interop-binfmt.service
+++ b/scripts/wsl/wsl-interop-binfmt.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Register WSL interop binfmt entry (.exe execution)
+# WSLではsystemd-binfmt.serviceがConditionVirtualization=!wslでスキップされ、
+# さらにqemu等のbinfmt登録がWSLInteropを消すことがあるため、ここで直接登録する
+ConditionPathExists=/proc/sys/fs/binfmt_misc/register
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '[ -e /proc/sys/fs/binfmt_misc/WSLInterop ] || echo ":WSLInterop:M::MZ::/init:PF" > /proc/sys/fs/binfmt_misc/register'
+
+[Install]
+WantedBy=multi-user.target

--- a/ssh/config
+++ b/ssh/config
@@ -1,5 +1,15 @@
 # SSH 鍵は Bitwarden Desktop の SSH agent で管理する（秘密鍵をディスクに置かない）
-# 接続時に必ず Bitwarden の socket を使うので、シェル起動タイミングに依存しない
 # 利用には Bitwarden Desktop の起動 + vault アンロックが必要
-Host *
+# socket が存在する Match だけが成立するので macOS / WSL2 で共用できる
+
+# macOS: Bitwarden Desktop が直接 socket を公開する
+Match exec "test -S ~/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"
     IdentityAgent ~/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock
+
+# WSL2: systemd user service (bitwarden-ssh-agent.service) が
+# Windows 側の named pipe を socat + npiperelay で中継する
+# IdentitiesOnly + 公開鍵指定で、vault内の他デバイスの鍵ではなくWSL用の鍵を使う
+Match exec "test -S ~/.bitwarden-ssh-agent.sock"
+    IdentityAgent ~/.bitwarden-ssh-agent.sock
+    IdentityFile ~/.ssh/id_ed25519_wsl.pub
+    IdentitiesOnly yes


### PR DESCRIPTION
## 概要

dotsfileをWSL2でも使えるようにする一連の修正と、WSLのSSH鍵をBitwarden Desktop (Windows側) のSSH agentに一本化する構成を追加。秘密鍵をWSLのディスクに置かない運用がmacOSとWSLの両方で揃う。

## 変更内容

### SSH (Bitwarden agent一本化)
- `ssh/config`: IdentityAgent をOS別の `Match exec` に分離。socketが存在する側だけ成立するのでmacOS/WSLで共用できる
- WSLは `IdentityFile ~/.ssh/id_ed25519_wsl.pub` + `IdentitiesOnly yes` でWSL専用鍵に固定(vault内の他デバイス鍵を使わない)

### WSL用systemdユニット (scripts/wsl/)
- `bitwarden-ssh-agent.service`: socat + npiperelay でWindowsのnamed pipe `openssh-ssh-agent` を `~/.bitwarden-ssh-agent.sock` に中継 (user unit)
- `wsl-interop-binfmt.service`: WSLでは `systemd-binfmt` が `ConditionVirtualization=!wsl` でスキップされ、qemu系binfmt登録でWSLInteropが消えるため、起動時に直接再登録する (system unit)

### setup_fish.sh
- Claude Code設定一式 (settings.json / statusline / agents / commands / hooks / rules / skills / sandbox) のsymlinkを追加
- WSL検出時にBitwardenブリッジのuser unitを自動セットアップ

### fish
- `config.fish`: `/Users/roy/.lmstudio/bin` ハードコードを `$HOME` ベース+存在チェックに
- `fzf.fish`: apt/Homebrewパス決め打ちを `fzf --fish | source` に変更 (devbox/nix環境で動く)
- `abbreviations.fish`: WSLでは `open` を `explorer.exe` に

### devbox
- ブリッジ用に `socat` を追加

## 検証
- WSLでagent単独 (`IdentitiesOnly yes`、ファイル鍵なし) のGitHub認証成功を確認
- `jj git fetch` / push がブリッジ経由で動作 (このPR自体がその鍵でpushされている)
- fish設定は `fish -n` とクリーン環境での起動で確認