### PR TITLE
fix(fish): SHELL を絶対パスに設定し ssh の Match exec 失敗を解消

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -22,7 +22,8 @@ set -gx TERM xterm-256color
 set -gx DFT_DISPLAY side-by-side-show-both
 
 # devbox
-set -gx SHELL fish
+# SSH の Match exec が $SHELL を execve するため絶対パスを設定する（裸の "fish" だと exec 失敗）
+set -gx SHELL (status fish-path)
 devbox global shellenv | source
 
 # JAVA_HOME (devbox's temurin)


### PR DESCRIPTION
## 概要

fish 起動時 `config.fish` で `$SHELL` を裸の `fish` に設定していたため、fish 経由で実行した `jj git fetch`（git→ssh）が失敗していた。

## 原因

OpenSSH の `Match exec` は `$SHELL` を使ってマッチ判定コマンドを execve する。`$SHELL=fish`（パス解決不可）だと exec に失敗し、`Permission denied` でその場で致命的に中断していた。

```
Unable to execute 'test -S ~/Library/.../.bitwarden-ssh-agent.sock': Permission denied
fatal: Could not read from remote repository.
```

- zsh から実行（`SHELL=/usr/bin/zsh` 絶対パス）→ 成功
- fish から実行（`SHELL=fish` 裸名）→ exec 失敗 → ssh 中断 → WSL 用 Match まで到達できず fetch 失敗

ssh config 自体は正常（`ssh -G` 直叩きはマッチ成功を確認済み）。

## 修正

`status fish-path` で実行中 fish の絶対パスを `$SHELL` に設定。nix store のパスが変わっても追従する。

## 検証

- `fish -l -c 'echo $SHELL'` → 絶対パスを確認
- `fish -l -c 'jj git fetch'` → exit 0 で成功