### PR TITLE
feat(zsh): dev 環境(devbox global/direnv)を読み込む zshrc を追加

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -1,0 +1,23 @@
+# zsh はインタラクティブ作業の主シェルではない（主は fish）が、
+# GUI 起動の Zed / Claude Code の Bash ツールが zsh を使うため、
+# fish と同じ dev 環境（devbox global 由来のツール）を揃えておく。
+
+# devbox global tools (jj, go, gh, node, pnpm, direnv, ...)
+command -v devbox >/dev/null && eval "$(devbox global shellenv)"
+
+# 追加 PATH（cargo / ローカル bin / npm global / gcloud）
+for d in "$HOME/.cargo/bin" "$HOME/.local/bin" \
+         "$HOME/.local/share/npm-global/bin" "$HOME/.local/google-cloud-sdk/bin"; do
+  [ -d "$d" ] && PATH="$d:$PATH"
+done
+export PATH
+
+# direnv: プロジェクトの .envrc 経由で repo-local の cld(go/bin) を通す
+command -v direnv >/dev/null && eval "$(direnv hook zsh)"
+
+# Added by LM Studio CLI (lms)
+export PATH="$PATH:/Users/roy/.lmstudio/bin"
+# End of LM Studio CLI section
+
+# Added by Devin
+export PATH="/Users/roy/.codeium/windsurf/bin:$PATH"


### PR DESCRIPTION
## 背景

Zed を GUI 起動で使い始めたところ、Claude Code の Bash ツール（zsh 利用）で `jj` / `cld` / `go` / `pnpm` / `gh` などが PATH に通っていなかった。

原因は dev 環境が **fish + devbox global** にしか設定されておらず、zsh 側（`~/.zshrc`）が devbox を読み込んでいなかったため。`create_symlink.sh` の `LINK_ITEMS` には既に `zshrc` が含まれているのに、`dotsfile/zshrc` の実体が欠落していた。

## 変更内容

- `dotsfile/zshrc` を新規追加
  - `devbox global shellenv` を eval（jj/go/gh/pnpm/node/direnv を解決）
  - cargo / `~/.local/bin` / npm-global / gcloud の PATH を追加
  - `direnv hook zsh` を追加（プロジェクトの `.envrc` 経由で repo-local の `cld` を解決）
  - 既存の LM Studio / Devin の自動追記行も保持
- `~/.zshrc` を実ファイルから `dotsfile/zshrc` へのシムリンクに張り替え（`create_symlink.sh` 規約どおり）

## 検証

新規 zsh で以下が解決することを確認:

- `jj` / `go` / `gh` / `pnpm` / `node` / `direnv` → devbox から解決 ✅
- `cld` → プロジェクト内で direnv（`.envrc` の `PATH_add go/bin`）経由で解決 ✅