### PR TITLE
perf(fish): fzf高速化とghq-fzfの改善

### DIFF
--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -6,6 +6,7 @@
     "bat@latest",
     "direnv@latest",
     "eza@latest",
+    "fd@latest",
     "fish@latest",
     "fzf@latest",
     "gh@latest",

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -100,6 +100,7 @@ source $__fish_config_dir/fzf.fish
 function ghq-get-cd
     ghq get $argv[1]
     and cd (ghq list --exact --full-path $argv[1])
+    rm -f "$HOME/.cache/ghq-fzf-list"  # ghq-fzfキャッシュを無効化（次回再生成）
 end
 
 # ghq get の略語用に関数を設定

--- a/fish/functions/fzf-cd-widget.fish
+++ b/fish/functions/fzf-cd-widget.fish
@@ -1,12 +1,13 @@
 function fzf-cd-widget --description 'Find directories with fzf and change to selected'
     set -l selected_dir (
-        find . -type d -not -path "*/\.git/*" -not -path "*/node_modules/*" \
+        fd --type d --hidden --exclude .git \
         | fzf --height 40% --layout reverse --border \
         --preview 'ls -la {}' --preview-window right:50%:wrap
     )
     
     if test -n "$selected_dir"
         cd $selected_dir
-        commandline -f repaint
     end
+    # 選択/キャンセル問わず再描画（escape時に表示が残るのを防ぐ）
+    commandline -f repaint
 end

--- a/fish/functions/fzf-file-widget.fish
+++ b/fish/functions/fzf-file-widget.fish
@@ -3,7 +3,7 @@ function fzf-file-widget --description 'Find files with fzf'
     
     # fzfでファイルを選択
     set -l selected_file (
-        find . -type f -not -path "*/\.git/*" -not -path "*/node_modules/*" \
+        rg --files --hidden --glob "!.git/*" \
         | fzf --height 40% --layout reverse --border \
         --preview 'bat --color=always --style=numbers --line-range=:500 {}' \
         --preview-window right:50%:wrap
@@ -11,6 +11,7 @@ function fzf-file-widget --description 'Find files with fzf'
     
     if test -n "$selected_file"
         commandline --current-token -- (string escape $selected_file)
-        commandline -f repaint
     end
+    # 選択/キャンセル問わず再描画（escape時に表示が残るのを防ぐ）
+    commandline -f repaint
 end

--- a/fish/functions/ghq-fzf-jj.fish
+++ b/fish/functions/ghq-fzf-jj.fish
@@ -4,9 +4,15 @@ function ghq-fzf-jj --description 'Select jj workspace with fzf and change direc
     set -l data_file (mktemp)
 
     # jj workspace (.jj/repo がファイルで親を参照しているもの)
-    find $ghq_root -name .jj -type d -maxdepth 5 2>/dev/null | while read jj_dir
+    fd -H -t d -d 5 '^\.jj$' $ghq_root 2>/dev/null | while read jj_dir
         if test -f $jj_dir/repo
-            echo (dirname $jj_dir)
+            set -l ws_path (dirname $jj_dir)
+            # forget済み(jj workspace listが空)なworkspaceは除外
+            set -l ws_alive (jj workspace list -R $ws_path 2>/dev/null)
+            if test -z "$ws_alive"
+                continue
+            end
+            echo $ws_path
         end
     end > $ws_file
 
@@ -87,6 +93,7 @@ function ghq-fzf-jj --description 'Select jj workspace with fzf and change direc
     if test -n "$src"
         set -l path (string split \t $src)[2]
         cd $ghq_root/$path
-        commandline -f repaint
     end
+    # 選択/キャンセル問わず再描画（escape時に表示が残るのを防ぐ）
+    commandline -f repaint
 end

--- a/fish/functions/ghq-fzf.fish
+++ b/fish/functions/ghq-fzf.fish
@@ -1,4 +1,104 @@
 function ghq-fzf --description 'Select ghq repository with fzf and change directory'
+    set -l cache_file "$HOME/.cache/ghq-fzf-list"
+
+    # --refresh でキャッシュを再生成（workspace追加時など手動更新用）
+    if test "$argv[1]" = --refresh
+        rm -f $cache_file
+    end
+
+    set -l ghq_root (ghq root)
+
+    # キャッシュが無ければリストを生成して保存（clone/workspace追加時のみ更新が必要）
+    if not test -f $cache_file
+        mkdir -p (dirname $cache_file)
+        set -l jj_file (mktemp)
+        set -l jj_parent_file (mktemp)
+
+        # jj workspace (.jj/repo がファイルで親を参照しているもの)
+        fd -H -t d -d 5 '^\.jj$' $ghq_root 2>/dev/null | while read jj_dir
+            if test -f $jj_dir/repo
+                set -l ws_path (dirname $jj_dir)
+                # forget済み(jj workspace listが空)なworkspaceは除外
+                set -l ws_alive (jj workspace list -R $ws_path 2>/dev/null)
+                if test -z "$ws_alive"
+                    continue
+                end
+                set -l parent_jj (cat $jj_dir/repo)
+                set -l parent_path (dirname (dirname $parent_jj))
+                echo $ws_path
+                # workspace と親のマッピングを保存
+                printf "%s\t%s\n" $ws_path $parent_path >> $jj_parent_file
+            end
+        end > $jj_file
+
+        # ghq list + jj workspace をマージし、jj workspace を親の直後にソート
+        begin; ghq list --full-path; cat $jj_file; end | awk -v ghq_root="$ghq_root" -v jj_parent_file="$jj_parent_file" '
+        BEGIN {
+            while ((getline line < jj_parent_file) > 0) {
+                split(line, f, "\t")
+                ws_parent[f[1]] = f[2]
+            }
+            close(jj_parent_file)
+        }
+        {
+            path = $0
+            short = path
+            sub(ghq_root "/", "", short)
+
+            # jj workspace の場合、親のパスをソートキーにする
+            if (path in ws_parent) {
+                parent = ws_parent[path]
+                parent_short = parent
+                sub(ghq_root "/", "", parent_short)
+                # ソートキー: 親のパス + /~ + workspace名で親の直後に来るようにする
+                n = split(short, parts, "/")
+                ws_name = parts[n]
+                print parent_short " " ws_name "\t" path "\t" parent
+            } else {
+                print short "\t" path "\t"
+            }
+        }
+        ' | sort -t\t -k1,1 | awk -F'\t' '!seen[$2]++ {print $2 "\t" $3}' | awk -F'\t' -v ghq_root="$ghq_root" -v jj_file="$jj_file" '
+            BEGIN {
+                while ((getline line < jj_file) > 0) jj_ws[line] = 1
+                close(jj_file)
+            }
+            {
+                line = $1
+                parent = $2
+                short = line
+                sub(ghq_root "/", "", short)
+                n = split(short, parts, "/")
+                host = parts[1]
+                owner = parts[2]
+                repo = parts[3]
+
+                if (host != prev_host) {
+                    printf "\033[3;36m── %s ──────────────────────\033[0m\n", host
+                    prev_host = host
+                    prev_owner = ""
+                }
+                if (owner != prev_owner) {
+                    printf "\033[3;36m── %s ──\033[0m\n", owner
+                    prev_owner = owner
+                }
+
+                if (line in jj_ws && parent != "") {
+                    # 親リポジトリ名/workspace名 で表示
+                    parent_short = parent
+                    sub(ghq_root "/", "", parent_short)
+                    pn = split(parent_short, pp, "/")
+                    parent_repo = pp[3]
+                    printf "\033[32m  󰘬 %s/%s\033[0m\t%s\n", parent_repo, repo, short
+                } else {
+                    printf "  %s\t%s\n", repo, short
+                }
+            }
+        ' > $cache_file
+
+        rm -f $jj_file $jj_parent_file
+    end
+
     set -l preview_command
     if command -q eza
         set preview_command "eza -TF --level=1 --icons"
@@ -6,92 +106,12 @@ function ghq-fzf --description 'Select ghq repository with fzf and change direct
         set preview_command "ls -l"
     end
 
-    set -l ghq_root (ghq root)
-    set -l jj_file (mktemp)
-    set -l jj_parent_file (mktemp)
-
-    # jj workspace (.jj/repo がファイルで親を参照しているもの)
-    find $ghq_root -name .jj -type d -maxdepth 5 2>/dev/null | while read jj_dir
-        if test -f $jj_dir/repo
-            set -l ws_path (dirname $jj_dir)
-            set -l parent_jj (cat $jj_dir/repo)
-            set -l parent_path (dirname (dirname $parent_jj))
-            echo $ws_path
-            # workspace と親のマッピングを保存
-            printf "%s\t%s\n" $ws_path $parent_path >> $jj_parent_file
-        end
-    end > $jj_file
-
-    # ghq list + jj workspace をマージし、jj workspace を親の直後にソート
-    set -l src (begin; ghq list --full-path; cat $jj_file; end | awk -v ghq_root="$ghq_root" -v jj_parent_file="$jj_parent_file" '
-    BEGIN {
-        while ((getline line < jj_parent_file) > 0) {
-            split(line, f, "\t")
-            ws_parent[f[1]] = f[2]
-        }
-        close(jj_parent_file)
-    }
-    {
-        path = $0
-        short = path
-        sub(ghq_root "/", "", short)
-
-        # jj workspace の場合、親のパスをソートキーにする
-        if (path in ws_parent) {
-            parent = ws_parent[path]
-            parent_short = parent
-            sub(ghq_root "/", "", parent_short)
-            # ソートキー: 親のパス + /~ + workspace名で親の直後に来るようにする
-            n = split(short, parts, "/")
-            ws_name = parts[n]
-            print parent_short " " ws_name "\t" path "\t" parent
-        } else {
-            print short "\t" path "\t"
-        }
-    }
-    ' | sort -t\t -k1,1 | awk -F'\t' '!seen[$2]++ {print $2 "\t" $3}' | awk -F'\t' -v ghq_root="$ghq_root" -v jj_file="$jj_file" '
-        BEGIN {
-            while ((getline line < jj_file) > 0) jj_ws[line] = 1
-            close(jj_file)
-        }
-        {
-            line = $1
-            parent = $2
-            short = line
-            sub(ghq_root "/", "", short)
-            n = split(short, parts, "/")
-            host = parts[1]
-            owner = parts[2]
-            repo = parts[3]
-
-            if (host != prev_host) {
-                printf "\033[3;36m── %s ──────────────────────\033[0m\n", host
-                prev_host = host
-                prev_owner = ""
-            }
-            if (owner != prev_owner) {
-                printf "\033[3;36m── %s ──\033[0m\n", owner
-                prev_owner = owner
-            }
-
-            if (line in jj_ws && parent != "") {
-                # 親リポジトリ名/workspace名 で表示
-                parent_short = parent
-                sub(ghq_root "/", "", parent_short)
-                pn = split(parent_short, pp, "/")
-                parent_repo = pp[3]
-                printf "\033[32m  󰘬 %s/%s\033[0m\t%s\n", parent_repo, repo, short
-            } else {
-                printf "  %s\t%s\n", repo, short
-            }
-        }
-    ' | fzf --ansi --color=fg:-1 --with-nth=1 --nth=1 --delimiter='\t' --preview "$preview_command $ghq_root/{2}")
-
-    rm -f $jj_file $jj_parent_file
+    set -l src (cat $cache_file | fzf --ansi --color=fg:-1 --with-nth=1 --nth=1 --delimiter='\t' --preview "$preview_command $ghq_root/{2}")
 
     if test -n "$src"
         set -l path (string split \t $src)[2]
         cd $ghq_root/$path
-        commandline -f repaint
     end
+    # 選択/キャンセル問わず再描画（escape時に表示が残るのを防ぐ）
+    commandline -f repaint
 end

--- a/fish/fzf.fish
+++ b/fish/fzf.fish
@@ -9,17 +9,27 @@ if command -q fzf
     # key bindings と補完を自前で生成できる
     fzf --fish | source
     
-    # fzf設定
+    # 共通設定: プレビューは付けない（履歴検索など不要な場面でbat起動を避ける）
     set -gx FZF_DEFAULT_OPTS '
-        --height 40% 
-        --layout reverse 
-        --border 
-        --preview "bat --color=always --style=numbers --line-range=:500 {}" 
+        --height 40%
+        --layout reverse
+        --border
+    '
+
+    # ファイル検索(Ctrl+T)のときだけbatプレビューを付ける
+    set -gx FZF_CTRL_T_OPTS '
+        --preview "bat --color=always --style=numbers --line-range=:500 {}"
         --preview-window right:50%:wrap
         --bind "ctrl-u:preview-page-up,ctrl-d:preview-page-down"
     '
-    
-    # fzf用のコマンド設定
-    set -gx FZF_CTRL_T_COMMAND 'find . -type f -not -path "*/\.git/*" -not -path "*/node_modules/*" -not -path "*/\.next/*"'
-    set -gx FZF_ALT_C_COMMAND 'find . -type d -not -path "*/\.git/*" -not -path "*/node_modules/*" -not -path "*/\.next/*"'
+
+    # ディレクトリ検索(Alt+C)はlsの軽いプレビュー
+    set -gx FZF_ALT_C_OPTS '
+        --preview "ls -la {}"
+        --preview-window right:50%:wrap
+    '
+
+    # fzf用のコマンド設定（rg/fd は devbox で導入。gitignore考慮で高速）
+    set -gx FZF_CTRL_T_COMMAND 'rg --files --hidden --glob "!.git/*"'
+    set -gx FZF_ALT_C_COMMAND 'fd --type d --hidden --exclude .git'
 end

--- a/zed/settings.jsonc
+++ b/zed/settings.jsonc
@@ -7,7 +7,8 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
-	"proxy": "",
+	"cli_default_open_behavior": "existing_window",
+ "proxy": "",
 	"agent_ui_font_size": 18.0,
 	"agent_buffer_font_size": 16.0,
 	"ui_font_family": "PlemolJP35 Console NF",
@@ -18,7 +19,11 @@
 	},
 	"vim_mode": true,
 	"terminal": {
-		"font_size": 16.0,
+		"toolbar": {
+   "breadcrumbs": false
+  },
+  "font_weight": 400.0,
+  "font_size": 14.0,
 		"font_family": "PlemolJP35 Console NF",
 		// fish を使用(PATH から解決。~ 展開・ユーザー名直書きを避けるため)
 		"shell": {


### PR DESCRIPTION
## 概要

fzfの体感速度を改善し、ghq-fzf(Ctrl+S)の不具合も修正。

## 変更点

### fzf高速化
- `FZF_DEFAULT_OPTS` のbatプレビューを場面別に分離。履歴検索(Ctrl+R)で毎回batが起動していたのを解消
- ファイル/ディレクトリ列挙を `find` → `rg --files` / `fd` に置換。gitignore考慮で高速化(devboxに `fd` 追加)

### ghq-fzf改善
- リポジトリ一覧をキャッシュ化し起動時の待ちを削減。`ghq get` 時に自動無効化、`ghq-fzf --refresh` で手動更新
- forget済みのjj workspaceが一覧に残る不具合を修正(`jj workspace list` の空判定で除外)
- escape(キャンセル)時の再描画漏れを修正。表示が固まる問題を解消

### その他
- zed: ターミナルtoolbar/フォント等の設定調整

## 動作確認
- 各fish関数の構文チェック(`fish -n`)
- find/fdの.jj検出数が一致(17件)を確認
- キャッシュ生成・forget済みworkspace除外を実機で確認

https://claude.ai/code/session_01W2EBnz7xdf66g78mVnNsCc