### PR TITLE
fix(fish): キーバインドにrepaintを追加しESCキャンセル時のプロンプトを再描画

### DIFF
--- a/fish/functions/fish_user_key_bindings.fish
+++ b/fish/functions/fish_user_key_bindings.fish
@@ -12,21 +12,22 @@ function fish_user_key_bindings --description 'Set custom key bindings and keep 
     end
 
     # ghq-fzf: Ctrl+S (BEAKL: sはホームロー下方向)
+    # 末尾の repaint で ESC キャンセル時もプロンプトを再描画する
     if functions -q ghq-fzf
-        bind \cs ghq-fzf
-        bind -M insert \cs ghq-fzf
+        bind \cs ghq-fzf repaint
+        bind -M insert \cs ghq-fzf repaint
     end
 
     # ghq-fzf-jj: Ctrl+T (BEAKL: tはホームロー上方向)
     if functions -q ghq-fzf-jj
-        bind \ct ghq-fzf-jj
-        bind -M insert \ct ghq-fzf-jj
+        bind \ct ghq-fzf-jj repaint
+        bind -M insert \ct ghq-fzf-jj repaint
     end
 
     # fzf-file-widget: Ctrl+G
     if functions -q fzf-file-widget
-        bind \cg fzf-file-widget
-        bind -M insert \cg fzf-file-widget
+        bind \cg fzf-file-widget repaint
+        bind -M insert \cg fzf-file-widget repaint
     end
 
     if functions -q fancy-ctrl-z


### PR DESCRIPTION
## 概要

fish のキーバインド (`ghq-fzf` / `ghq-fzf-jj` / `fzf-file-widget`) に `repaint` を追加し、ESC でキャンセルした際もプロンプトが再描画されるようにする。

## 変更内容

- `bind` の各ウィジェット呼び出し末尾に `repaint` を付与
- insert モードのバインドも同様に対応

https://claude.ai/code/session_01JBBqjWU6fem7XkcQp25kga