### PR TITLE
feat: cmux関連スキルと設定をdotsfile管理化

### DIFF
--- a/.agents/skills/cmux-architecture/SKILL.md
+++ b/.agents/skills/cmux-architecture/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: cmux-architecture
+description: "cmux package architecture, refactor layering, dependency inversion, file organization, DocC documentation, package design discipline, testability, and Swift 6 concurrency rules. Use before adding or meaningfully rewriting Swift files, Swift packages, coordinators, services, repositories, or public package APIs."
+---
+
+# cmux Architecture
+
+## Package architecture
+
+We are migrating cmux from a single app target into Swift Packages under `Packages/`. Every new package must satisfy three rules:
+
+- **Ergonomic.** Public API surface matches what callers naturally want to write. Default to internal access; expose `public` only for types and functions that downstream consumers actually use. Avoid friction such as forcing every call site through a builder or wrapper when a direct API is fine.
+- **No dependency cycles.** Packages form a strict DAG. A package may only depend on packages strictly lower in the graph. When two packages need to share a type, lift it to a common lower-level package or define a protocol seam in the consumer. Every new dependency edge requires re-checking that the graph stays acyclic.
+- **Clear but not overly narrow responsibilities.** A package owns one full domain (e.g. _settings_, _appearance_, _workspace_, _terminal_, _browser_, _command palette_), not a slice of one. A package called "appearance math" or "workspace model" is too narrow — it forces every consumer that touches the surrounding domain to also depend on the sibling slices. Prefer a single `CmuxAppearance` that owns settings, theming, colors, glass, and snapshots together, over `CmuxAppearanceMath` + `CmuxAppearanceTheme` + `CmuxAppearanceSettings`. Don't fragment a domain into `CmuxFooFormatting` + `CmuxFooLogic` + `CmuxFooState` — that's folder structure inside a single package, not module structure. A package boundary exists because more than one consumer needs the contents, or a build/test seam needs to exist.
+
+When in doubt, **extract leaf-first**: pull out the package that has no internal dependencies. Consumers in the app target stay put and only update imports. Each leaf shrinks the app target without requiring downstream packages to exist yet.
+
+The existing packages under `Packages/` predate this policy and should not be used as design references.
+
+**Wiring a new local package into the project.** `cmux.xcodeproj` lists package dependencies explicitly (it is not a synchronized-folder project). Adding `Packages/CmuxFoo` means mirroring an existing package's `project.pbxproj` entries — one `XCLocalSwiftPackageReference` (in the project's `packageReferences`), one `XCSwiftPackageProductDependency`, and a `PBXBuildFile` linked in the Frameworks phase of **every** target that imports it. The app-target packages link into **both** `cmux` and `cmux-unit` (so tests can `import` and inject them); copy a recent leaf like `CmuxSocketControl` for the exact shape, then run `scripts/normalize-pbxproj.py` and `scripts/check-pbxproj.sh`. A package the app builds against but `cmux-unit` does not link will compile the app yet fail the test target.
+
+## Refactor architecture: layers, Coordinator/Service/Repository, dependency inversion
+
+These higher-level patterns are binding on every new or moved/meaningfully-rewritten file. (The full blueprint, with worked examples and the per-god decomposition, lives in the cmuxterm-hq control repo under `docs/cmux-refactor-audit/blueprint/`; the enforceable core is below.)
+
+**Layered, downward-only DAG.** Packages form a strict acyclic graph in five layers; dependencies point only downward:
+
+1. **Core** (e.g. `CmuxCore`) — pure `Sendable` values, IDs, DTOs, errors, and the protocol seams shared across domains. No AppKit/SwiftUI/I/O. The lift target when two domains need the same type.
+2. **Services / infrastructure** — `actor`s implementing core protocols against the outside world (process/PTY, filesystem, sockets, web API, notifications, auth). One package per cohesive capability.
+3. **Domain / state** — `@MainActor @Observable` models + Coordinators, one package per feature domain; owns that domain's mutable state. `CmuxSettings` is the exemplar.
+4. **UI** — SwiftUI/AppKit views, one UI package per domain package, depending only on its domain package + Core, never on a Service directly. `CmuxSettingsUI` is the exemplar.
+5. **Executable** (`cmuxApp` / `AppDelegate`) — a thin composition shim, no business logic.
+
+**Classify every extracted entity by intent:**
+
+- **Coordinator** — a `@MainActor @Observable` orchestrator that sequences a user flow and owns navigation/selection/lifecycle state, calling Services and child models. Does no I/O itself.
+- **Service** — an `actor` (or `@MainActor` only when an AppKit main-thread API forces it) performing one outside-world capability; exposes `async`/`await` + `AsyncStream`, holds only its own resource handles, holds no UI state.
+- **Repository** — an `actor` mediating one persistence source of truth (file, defaults, web API) behind CRUD-shaped async methods returning value types. Precedents: `JSONConfigStore`, `UserDefaultsSettingsStore`.
+
+**Dependency inversion.** Lower packages publish protocols; concrete Services/Repositories conform; higher layers depend on `any Protocol`, never the concrete type. Share a type by lifting it to Core or defining a protocol seam in the consumer — never a stored property reaching across modules. Injection is constructor (`init`) injection only: no global container, no singleton, no `static let shared`. The **executable app target is the single composition root** — the one place concretes are named and the object graph is assembled. SwiftUI `Environment` may carry already-constructed `@Observable` models down a view tree (as `SettingsRuntime` does), but is never the source of truth for service wiring.
+
+**State + SwiftUI wiring.** Domain state lives in `@MainActor @Observable` models (never `ObservableObject`/`@Published`). A god model decomposes into cohesive child `@Observable` sub-models owned by their domain packages and composed by the home object via held references; cross-domain reads go behind read-only protocols. In views use `@State` (owned), `@Bindable` / plain `let` (passed-in), or `@Environment(M.self)` + `.environment(...)` (injected) — never `@StateObject` / `@ObservedObject` / `@EnvironmentObject` / `.environmentObject(_:)`.
+
+**Executable-target boundary (three hard constraints — invert, never work around):**
+
+1. `@main` `cmuxApp` and `AppDelegate` stay in the executable target as the thin composition shim; that residual is the intended end state, not debt.
+2. A type is declared in exactly one module and a lower package cannot extend a higher-owned type, so `AppDelegate+*` / `cmuxApp+*` / `Workspace+*` extensions do not move down: extract the behavior into a Coordinator/Service/Repository, have the god object own an instance, and reduce the extension to a one-line forward.
+3. Stored properties cannot cross module boundaries: decompose god-model state into child `@Observable` sub-models owned by domain packages, composed by held reference, with cross-cutting reads behind read-only protocols.
+
+## File organization
+
+One major type per file. Each `struct`, `class`, `enum`, `actor`, or `protocol` that is part of a public API (or has any meaningful body) lives in its own file named after the type (`Control.swift`, `LabeledChoice.swift`, `ListControl.swift` — not one shared `SettingControl.swift`). This rule applies to all new code in `Packages/` and to any new files added to the app target.
+
+- Small, closely-bound helpers (`private struct`, nested types, single-line extensions used only inside the file) can stay with the parent type. Anything bigger or independently meaningful gets its own file.
+- Conformance-adding extensions for a type defined elsewhere go in `TypeName+Conformance.swift` or `TypeName+Feature.swift`, not bundled into the consuming feature file.
+- Type-erased wrappers (`AnyFoo`) live next to the type they erase (`Foo.swift` and `AnyFoo.swift`), each in its own file.
+- Existing god files (`ContentView.swift`, `Workspace.swift`, `TabManager.swift`, `cmuxApp.swift`) are the pattern this rule exists to stop. When migrating code out of them, split into one file per type even if it triples the file count. File count is cheap; "find this type" being unanswerable is expensive.
+
+## Documentation
+
+Every `public` symbol in any new Swift package under `Packages/` is documented with a Swift-DocC triple-slash comment at the time of writing. Treat docs as part of the API surface, not as follow-up work.
+
+- **Format.** Use `///` doc comments above the symbol. First line is a one-sentence summary that fits on a single line and ends with a period. If more context is needed, leave a blank `///` line, then add a discussion paragraph. Use `- Parameter name:` / `- Returns:` / `- Throws:` callouts on `init` and `func` symbols that take parameters or throw. Use Markdown freely (bold, fenced code blocks for examples, backticks for inline code).
+- **Cross-references.** Refer to other symbols using double-backticks: `` ``CmuxSetting`` ``. Plain backticks are for non-symbol code (`UserDefaults.standard`, `@AppStorage`).
+- **What to document on each symbol.** Types: what they represent and when to use them. Enums: meaning of each case. Init parameters: especially defaults and the reason for them. Properties: what value they hold and any invariants. Methods: what they do, plus parameters/returns/throws. Generic constraints: which `Value` / `Element` shapes the type accepts and why (e.g., `Sendable & Codable`).
+- **Examples.** Non-trivial APIs get at least one example in a fenced ` ```swift ` block, ideally a real declaration from this codebase. Keep examples short and idiomatic.
+- **Internal vs public.** `internal` and `private` symbols get a one-line `///` when the intent is non-obvious; verbosity is not required at that scope. The public boundary is the one that needs full coverage.
+- **No stale docs.** When you change a symbol's behavior or signature, update its doc comment in the same edit. Docs that describe last week's behavior are worse than no docs.
+- **Don't comment-narrate the body.** Doc comments describe the contract from the outside. Inline `//` comments inside method bodies are reserved for non-obvious *why*, not *what* (the existing rule from the top-level guidance still applies).
+
+This rule applies to all packages under `Packages/`. Code in the main app target is not retroactively required to be documented, but new `public` symbols added to packages must be.
+
+## Package design discipline
+
+These are the recurring design mistakes that have to be caught at the design step, not at code review:
+
+- **No shared-singleton accessors.** `static let standard` / `shared` / `default` on a package type that holds runtime state is a singleton-by-another-name. Construct the package type at the app's startup site and inject it. `static let` is fine for *declarations* — identifiers, schema entries, enum cases — but not for behavior.
+- **No namespace-enums.** `enum Foo { static func bar() }` (a no-case enum used as a namespace) is a fake namespace that fights the rest of the design (no instances, no DI, no test seam). Prefer a value-typed struct passed via constructor when the helper might gain configuration, or a file-scope `private func` for pure helpers internal to one file.
+- **No parallel hand-maintained registries.** When a list mirrors a set of declared items (e.g. `catalog.all` mirroring the catalog's stored properties), derive the list via `Mirror` reflection or a macro. Two sources of truth drift silently; the IDE doesn't tell you.
+- **Prefer compile-time invariants to runtime traps.** If the pattern is `guard ... else { assertionFailure(...); return default }` for a "programmer error" case, encode it in the type system (phantom types, separate concrete flavors). Runtime traps become silent fallbacks in release builds.
+- **No free functions.** Functionality is always scoped to an entity that owns the responsibility: a method on a value type, an extension on the type the operation belongs to, or a member of the Coordinator/Service/Repository that uses it. Top-level `func` declarations (any visibility, including file-scope `private func`) are banned. The only sanctioned exception is a `@convention(c)` trampoline a C API forces on us, marked with a one-line justification.
+- **Nested types still count for the one-major-type-per-file rule.** A `private final class WatcherAttachment` inside `JSONConfigFileWatcher.swift` is a major type. Move it to its own file the moment it has a meaningful body.
+
+## Testability
+
+Every public type added to `Packages/` must be **testable from a test target** without launching the app target, without booting AppKit, and without depending on the user's filesystem or `UserDefaults.standard`. Production-grade designs surface a test seam at every boundary:
+
+- **No global state in package code.** Every public type that needs `UserDefaults`, `FileManager`, an on-disk path, an environment variable, or a clock takes it via initializer parameter. Tests pass a `UserDefaults(suiteName:)` scoped to the test, a temp directory URL, a fixed `Date`, etc.
+- **No reliance on `.shared` / `.standard`.** A public type that hardcodes `UserDefaults.standard` or `FileManager.default` inside its implementation cannot be tested without polluting the developer's actual settings. Inject these at the seam.
+- **Test through injected seams, never a static test hook.** A `nonisolated(unsafe) static var fooForTesting` (or any global mutable "override" a test swaps in) is global state by another name: it leaks across tests, forces `nonisolated(unsafe)`, and usually needs a lock. Replace it with a protocol seam injected through `init` (e.g. `init(commandRunner: any CommandRunning = CommandRunner())`); the test passes a conforming fake. When you extract such a type into a package, deleting the static hook (and the lock it required) is part of the extraction, not a follow-up.
+- **Public APIs return values, not side effects, where possible.** A function that mutates global UserDefaults and returns `Void` is harder to test than one that returns the changed value and lets the caller persist. Prefer pure transformations + thin imperative layers.
+- **Asynchronous APIs surface their observation as `AsyncStream`.** Tests can iterate `AsyncStream` deterministically and assert the sequence of yielded values. Avoid `NotificationCenter`-only patterns where the test has to spin a runloop.
+- **Document the test pattern** alongside any non-trivial public surface. The package's `README.md` and any DocC catalog should show how to instantiate the type with test-friendly dependencies.
+
+If a design is hard to test, it is wrong. Reach for the constructor parameter list, not the test bench.
+
+## Modern Swift concurrency
+
+All new code in `Packages/` and any new files added to the app target use Swift 6 concurrency primitives: `actor`, `async`/`await`, `AsyncStream`/`AsyncSequence`, `@Observable`, `@MainActor`. Old primitives — locks, manual KVO, `@Published`, completion handlers, `DispatchQueue` used as a serial lock — are not allowed.
+
+If you find yourself reaching for a lock to protect ongoing mutable shared state, the type is almost always the wrong shape — promote it to an `actor`. The exception is the narrow lock carve-out below.
+
+**Do not introduce a single-method `actor` purely as a mutex.** An `actor Guard { func claim() -> Bool }` whose only job is to guard a flag is a lock with extra ceremony: it forces synchronous callers — a `Process` termination handler, a `DispatchSource` event handler, a `withCheckedContinuation` resume race — through `Task { await guard.claim() }`, which adds suspension points, ordering hops, and reentrancy surface to what is fundamentally a synchronous compare-and-set. That makes the code worse, not safer. A tiny synchronous guard like that belongs in the lock carve-out, not an actor.
+
+When **extracting** existing code that uses a forbidden primitive into a package, reconsider the shape at the seam rather than copying it blindly — usually it wants an `actor`. But a one-shot single-resume guard (a `Process` termination handler vs. a timeout vs. a spawn failure racing to resume one `withCheckedContinuation`) is exactly a case the lock carve-out covers: keep a synchronous primitive, hidden behind the type. Drain `Process` pipes concurrently on detached tasks keyed by the raw fd (an `Int32` is `Sendable`; a `FileHandle` is not).
+
+**Forbidden in new code (no exceptions without a written justification in the PR description):**
+
+- **Locks.** `NSLock`, `NSRecursiveLock`, `os_unfair_lock`, `OSAllocatedUnfairLock`, `pthread_mutex_t`, `Synchronization.Mutex`, `DispatchSemaphore` used as a lock. Use `actor` isolation. Mutable shared state belongs in an actor; reads and writes are `async`. (Narrow carve-out below: a lock is allowed where the `actor`/`async` alternative would genuinely worsen the code, with justification.)
+- **KVO via `NSObject` subclassing.** Any `class Foo: NSObject` whose purpose is to override `observeValue(forKeyPath:...)` or call `addObserver(_:forKeyPath:...)`. Replace with `NotificationCenter.default.notifications(named:)` `AsyncSequence`, or the `NSKeyValueObservation` token API at the seam only.
+- **`DispatchQueue` used as a synchronization primitive.** A `DispatchQueue(label:)` accessed via `queue.sync { ... }` to serialize mutable state is a lock with different syntax. Use an `actor`. Queues are fine for *event delivery* (e.g. a `DispatchSource` handler), not for protecting state.
+- **Combine for change propagation.** No `@Published`, no `ObservableObject`, no `PassthroughSubject`/`CurrentValueSubject`, no `AnyCancellable` for change observation. Use `@Observable` (Observation framework, Swift 5.9+) for SwiftUI state, or `AsyncStream`/`AsyncSequence` for cross-actor change propagation.
+- **Completion-handler APIs.** Authoring a new public API with a `(Result<T, Error>) -> Void` or `(T?, Error?) -> Void` callback is forbidden. Use `async throws -> T`. When wrapping a legacy callback at the boundary, use `withCheckedContinuation`/`withCheckedThrowingContinuation` and keep it confined to that one seam.
+- **`DispatchQueue.main.async { ... }`.** Annotate the destination with `@MainActor`. Call sites either `await` the main-isolated function or are themselves `@MainActor`.
+- **Sleeping as a synchronization substitute.** `Task.sleep` / `Clock.sleep` (or any sleep) used to *poll* for a condition, to let state "settle" before reading it, or to *race* a callback/animation is forbidden — use a real signal (`AsyncStream`, `NSKeyValueObservation`, a completion, a state change). `DispatchQueue.asyncAfter` is banned outright (it is neither cancellable-by-structure nor testable). A *bounded, cancellable, intended* delay or deadline is allowed under the `Clock.sleep` carve-out below.
+
+**Required shape:**
+
+- Mutable shared state → `actor`. Reads/writes/reset are `async`. Observers receive `AsyncStream` returned by the actor.
+- SwiftUI view-render-friendly state → `@Observable @MainActor` view-model that subscribes to the actor's `AsyncStream` and projects snapshots. Don't read actor state synchronously from view code.
+- Cross-process / cross-thread invariants → expressed via actor isolation, not via locks or queues.
+- New public observable surfaces → `AsyncStream` or `AsyncSequence`. Not callbacks, not `@Published`, not raw `NotificationCenter` subscription.
+
+**Acceptable with a one-line justification comment on the declaration:**
+
+These low-level primitives have no async-native replacement. They must be hidden behind an `AsyncStream` or `actor` surface; callers never see them.
+
+- `DispatchSource.makeFileSystemObjectSource` for file watching (no Foundation async equivalent).
+- `DispatchSource.makeReadSource`/`makeWriteSource` for low-level socket I/O.
+- **A bounded, cancellable `Clock.sleep` (preferred) or `Task.sleep` for a genuine delay/deadline** that is itself the intended behavior — a minimum display duration, an auto-dismiss, a check timeout. Drive it from an *injected* `Clock` (or a duration) so tests advance virtual time with no real waiting, and wire the sleeping `Task`'s cancellation to the relevant lifecycle so a state transition cancels the pending delay (store the `Task`, cancel it on transition; or use `withTaskCancellationHandler`). For true delays/deadlines only, never to poll, settle, or race — those still require a real signal. One-line justification on the call site.
+- `DispatchSource.makeTimerSource` (one-shot) **only when a genuine deadline must fire outside any async context** — a non-`async` type with no `Task` to host the sleep. Prefer the `Clock.sleep` carve-out above whenever the code is already on an actor or in async code (it is cancellation-integrated and testable; a raw `DispatchSource` timer is not, and has suspend/resume/cancel footguns). Hide the timer behind the type, cancel it on the non-timeout path, and never use it to poll or fake a sleep.
+- A **lock for a synchronous compare-and-set called from non-async callbacks**, where promoting to an `actor` would only add `Task`/`await` hops and reentrancy. The canonical case is a one-shot resume guard: several synchronous `Process`/`DispatchSource` callbacks race to resume one `withCheckedContinuation` exactly once. `OSAllocatedUnfairLock(initialState:)` guarding a `Bool` (claimed once, checked synchronously in each callback) is correct, deterministic, and lets the callback resume the continuation inline. This carve-out is for short, non-blocking critical sections over a tiny flag/counter — not for guarding ongoing domain state (that is still an `actor`). Keep it private to the type, with a one-line justification.
+- `NSKeyValueObservation` token (the closure-based API) when wrapping a Foundation/AppKit type that exposes change only via KVO.
+
+**`@unchecked Sendable` and `nonisolated(unsafe)`:**
+
+Both require a comment on the declaration explaining the safety argument. Examples that pass review:
+
+```swift
+// Wraps DispatchSourceFileSystemObject; every mutation happens on `queue`.
+private final class WatcherAttachment: @unchecked Sendable { ... }
+
+// UserDefaults is Apple-documented thread-safe; OK to read nonisolated.
+private nonisolated(unsafe) let defaults: UserDefaults
+```
+
+Without a justification comment, the diff is rejected. `@unchecked Sendable` on an entire actor or struct is almost always wrong; prefer `nonisolated(unsafe) let` on the single non-Sendable property.
+
+**Scope and enforcement:**
+
+- Applies to: every new file in `Packages/`, every new file in the app target, every meaningful rewrite of an existing Swift file.
+- Existing app target code may continue to use the old primitives until rewritten. Do not retrofit blindly.
+- Code review checklist (Codex, CodeRabbit, Greptile, and human reviewers): reject diffs that introduce `@Published`/`ObservableObject`/`DispatchQueue.main.async`/`addObserver(_:forKeyPath:...)`/`DispatchQueue.asyncAfter` in new code, or `Task.sleep`/`Clock.sleep` used to poll, settle, or race rather than as a bounded, cancellable, injected-clock delay with justification. Reject a lock (`NSLock`/`OSAllocatedUnfairLock`/etc.) or `@unchecked Sendable`/`nonisolated(unsafe)` unless it falls under a documented carve-out *and* carries a one-line justification — and reject a single-method `actor` that exists only to guard a flag (use the lock carve-out instead).
+
+## Detailed references
+
+- Read [references/package-boundaries.md](references/package-boundaries.md) for detailed package extraction, dependency graph, composition-root, and pbxproj wiring guidance.
+- Read [references/concurrency-carveouts.md](references/concurrency-carveouts.md) for detailed examples and review guidance around actors, locks, DispatchSource, sleep, `@unchecked Sendable`, and `nonisolated(unsafe)`.
+- Read [references/file-api-discipline.md](references/file-api-discipline.md) for one-type-per-file, DocC, public API, and design-smell details.

--- a/.agents/skills/cmux-architecture/agents/openai.yaml
+++ b/.agents/skills/cmux-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Architecture"
+  short_description: "Apply cmux package, refactor, file organization, DocC, testability, and concurrency rules."
+  default_prompt: "Use this skill before adding or meaningfully rewriting Swift files, Swift packages, coordinators, services, repositories, package APIs, or Swift concurrency code in cmux."

--- a/.agents/skills/cmux-architecture/references/concurrency-carveouts.md
+++ b/.agents/skills/cmux-architecture/references/concurrency-carveouts.md
@@ -1,0 +1,114 @@
+# Concurrency Carve-outs
+
+This reference expands the Swift 6 concurrency rules.
+
+## Default shape
+
+Use modern Swift primitives:
+
+- `actor` for mutable shared state
+- `async`/`await` for asynchronous APIs
+- `AsyncStream` or `AsyncSequence` for observation
+- `@Observable @MainActor` for SwiftUI-facing state
+- `@MainActor` instead of `DispatchQueue.main.async`
+
+Do not add new `@Published`, `ObservableObject`, completion-handler APIs, KVO observer overrides, or queue-as-lock patterns in new package code or meaningful rewrites.
+
+## Actor, not lock
+
+Ongoing mutable shared state belongs in an actor. If the state has a lifecycle, multiple operations, or can be observed, an actor is almost always the right shape.
+
+Example actor-owned responsibilities:
+
+- process registry
+- file watcher state
+- socket session table
+- retry/idempotency state
+- provider lifecycle state
+
+## Single-method actor smell
+
+Do not introduce an actor whose only job is to guard a boolean flag:
+
+```swift
+actor ResumeGuard {
+    func claim() -> Bool { ... }
+}
+```
+
+That pattern is usually a lock with extra suspension and reentrancy surface. In synchronous callback races, the callback often needs an immediate compare-and-set, not a `Task { await ... }` hop.
+
+## Lock carve-out
+
+A private lock is acceptable for a short, synchronous compare-and-set called from non-async callbacks where an actor would worsen ordering and reentrancy.
+
+Canonical case:
+
+- process termination handler
+- timeout callback
+- spawn failure callback
+- all race to resume exactly one `withCheckedContinuation`
+
+Use a tiny private guard, document the reason on the declaration, and keep the critical section non-blocking.
+
+This carve-out does not allow locking ongoing domain state.
+
+## DispatchSource carve-outs
+
+These low-level primitives have no async-native replacement and are acceptable behind an async or actor surface:
+
+- `DispatchSource.makeFileSystemObjectSource`
+- `DispatchSource.makeReadSource`
+- `DispatchSource.makeWriteSource`
+
+Hide the source behind the type. Callers should see an `AsyncStream`, `AsyncSequence`, or actor API, not raw DispatchSource lifecycle.
+
+## Sleep carve-out
+
+`Clock.sleep` or `Task.sleep` is acceptable only for a genuine bounded delay or deadline that is the intended behavior:
+
+- minimum display duration
+- auto-dismiss
+- check timeout
+- deadline for a provider operation
+
+It is not acceptable for polling, settling UI state, or racing an animation/callback.
+
+Prefer an injected `Clock` or duration so tests can advance virtual time. Store and cancel sleeping tasks on lifecycle transitions.
+
+## Timer source carve-out
+
+Use `DispatchSource.makeTimerSource` only when a genuine deadline must fire outside any async context and there is no task to host `Clock.sleep`.
+
+Prefer `Clock.sleep` whenever the code is already async or actor-isolated.
+
+## Sendability escape hatches
+
+`@unchecked Sendable` and `nonisolated(unsafe)` require comments on the declaration explaining why the usage is sound.
+
+Good examples:
+
+```swift
+// Wraps DispatchSourceFileSystemObject; every mutation happens on `queue`.
+private final class WatcherAttachment: @unchecked Sendable { ... }
+
+// UserDefaults is Apple-documented thread-safe; OK to read nonisolated.
+private nonisolated(unsafe) let defaults: UserDefaults
+```
+
+Prefer narrowing the escape hatch to one property rather than marking an entire actor or value type unchecked.
+
+## Review checklist
+
+Reject diffs that introduce any of these in new code without a documented carve-out:
+
+- `@Published`
+- `ObservableObject`
+- `DispatchQueue.main.async`
+- `DispatchQueue.asyncAfter`
+- `addObserver(_:forKeyPath:...)`
+- queue-as-lock synchronization
+- lock for ongoing mutable state
+- `Task.sleep` or `Clock.sleep` used to poll/settle/race
+- `@unchecked Sendable` without a safety comment
+- `nonisolated(unsafe)` without a safety comment

--- a/.agents/skills/cmux-architecture/references/file-api-discipline.md
+++ b/.agents/skills/cmux-architecture/references/file-api-discipline.md
@@ -1,0 +1,86 @@
+# File and API Discipline
+
+This reference expands file organization, documentation, and design-smell rules.
+
+## One major type per file
+
+Each meaningful `struct`, `class`, `enum`, `actor`, or `protocol` lives in its own file named after the type.
+
+This applies to:
+
+- public API types
+- internal types with meaningful bodies
+- private nested types that have grown beyond a tiny helper
+- type-erased wrappers
+- conformance extensions for externally owned types
+
+File count is cheap. Not knowing where a type lives is expensive.
+
+## Allowed small helpers
+
+Small, closely-bound helpers can stay with the parent type when they are private and trivial:
+
+- a tiny nested enum used only for local branching
+- a one-line private extension
+- a local helper that does not have independent behavior
+
+Move the helper once it has meaningful lifecycle, state, protocol conformance, or enough logic to test independently.
+
+## Extension files
+
+Conformance-adding extensions for a type defined elsewhere go in files such as:
+
+- `TypeName+Conformance.swift`
+- `TypeName+Feature.swift`
+
+Do not hide important conformances inside unrelated feature files.
+
+## DocC for public package APIs
+
+Every public symbol in new Swift packages under `Packages/` needs a `///` DocC comment at the time it is written.
+
+Document:
+
+- what a type represents
+- when to use it
+- enum case meaning
+- property invariants
+- init parameters and defaults
+- method parameters, returns, and throws
+- generic constraints
+
+Use double-backtick symbol references for symbols:
+
+```swift
+/// Stores a typed ``CmuxSetting`` value.
+```
+
+Use plain backticks for non-symbol code:
+
+```swift
+/// Reads from `UserDefaults.standard` only when injected by the caller.
+```
+
+## Design smells
+
+Avoid runtime state singletons:
+
+- `static let shared`
+- `static let standard`
+- `static let default`
+
+Static declarations are fine for identifiers, schema entries, and enum cases. Runtime behavior should be constructed at app startup and injected.
+
+Avoid namespace enums:
+
+```swift
+enum Foo {
+    static func bar() { ... }
+}
+```
+
+If behavior may need configuration or a test seam, use a value type or service. If it is a pure local helper, keep it private near its caller.
+
+Avoid parallel hand-maintained registries. If a list mirrors declared items, derive it via reflection or a macro where practical.
+
+Prefer compile-time invariants to runtime traps. A `guard` plus `assertionFailure` plus fallback often means the type model is too weak.

--- a/.agents/skills/cmux-architecture/references/package-boundaries.md
+++ b/.agents/skills/cmux-architecture/references/package-boundaries.md
@@ -1,0 +1,89 @@
+# Package Boundaries
+
+This reference expands cmux package extraction and refactor architecture rules.
+
+## Why package boundaries exist
+
+A package boundary should exist because more than one consumer needs the domain, because a build/test seam is useful, or because the package isolates a cohesive external capability. It should not exist just to make a file list look smaller.
+
+Good package names describe a domain:
+
+- `CmuxSettings`
+- `CmuxSettingsUI`
+- `CmuxAppearance`
+- `CmuxWorkspace`
+- `CmuxBrowser`
+- `CmuxSocketControl`
+
+Weak package names describe a slice:
+
+- `CmuxAppearanceMath`
+- `CmuxWorkspaceModel`
+- `CmuxFooFormatting`
+- `CmuxFooLogic`
+- `CmuxFooState`
+
+Slices force callers to depend on several sibling packages any time they touch the real domain.
+
+## Dependency graph
+
+Packages form a strict downward-only DAG:
+
+1. Core: pure `Sendable` values, IDs, DTOs, errors, and protocol seams. No AppKit, SwiftUI, or I/O.
+2. Services/infrastructure: actors implementing core protocols against external systems.
+3. Domain/state: `@MainActor @Observable` models and Coordinators.
+4. UI: SwiftUI/AppKit views that depend on domain packages and Core, not services directly.
+5. Executable: `cmuxApp` and `AppDelegate` as the composition root.
+
+If two domains need a shared type, lift the type to a lower package or define a protocol seam. Do not make sibling packages reach sideways.
+
+## Extract leaf-first
+
+When uncertain, extract the package that has no internal dependencies first. This keeps the migration incremental and avoids needing several downstream packages to exist before one package can compile.
+
+Leaf-first extraction also makes review easier:
+
+- fewer dependency edges
+- fewer project-file entries
+- simpler tests
+- clearer rollback path
+
+## Composition root
+
+The executable app target is the single composition root. Concrete services and repositories are named there and injected into coordinators/models.
+
+Do not introduce:
+
+- global containers
+- runtime state singletons
+- `static let shared`
+- service lookups from package internals
+
+SwiftUI `Environment` may carry already-constructed observable models down a view tree. It should not become the source of truth for service wiring.
+
+## Executable target boundary
+
+`@main` `cmuxApp` and `AppDelegate` stay in the executable target. Do not move extensions of executable-owned types down into lower packages. A lower package cannot extend a higher-owned type without creating the wrong dependency direction.
+
+Instead:
+
+1. Extract behavior into a Coordinator, Service, or Repository in the appropriate package.
+2. Inject it into the god object or app composition root.
+3. Reduce the original extension to a one-line forward if it must remain.
+
+## pbxproj wiring
+
+`cmux.xcodeproj` lists package dependencies explicitly. Adding `Packages/CmuxFoo` means mirroring existing package entries:
+
+- one `XCLocalSwiftPackageReference`
+- one `XCSwiftPackageProductDependency`
+- one `PBXBuildFile` linked in the Frameworks phase of every target that imports it
+
+App-target packages link into both `cmux` and `cmux-unit`, so tests can import and inject them. A package linked by the app but not `cmux-unit` can make the app build pass while the test target fails.
+
+After editing the project file, run:
+
+```bash
+scripts/normalize-pbxproj.py
+scripts/check-pbxproj.sh
+```

--- a/.agents/skills/cmux-backend/SKILL.md
+++ b/.agents/skills/cmux-backend/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cmux-backend
+description: "Backend TypeScript and Cloud VM development rules for cmux. Use when editing web/app/api, web/services, backend scripts, Cloud VM lifecycle, provider integrations, Postgres, Stack Auth pricing gates, migrations, or provider image build scripts."
+---
+
+# cmux Backend
+
+Use this skill for backend TypeScript, Cloud VM, provider, database, auth, rate-limit, retry, timeout, or telemetry work.
+
+## Core rules
+
+- Default backend TypeScript to Effect under `web/app/api/**`, `web/services/**`, and backend scripts that touch providers, databases, auth, rate limits, retries, timeouts, or telemetry.
+- Keep Next route handlers thin: parse the request, run one Effect program at the boundary, map typed errors to HTTP responses, and treat unexpected defects separately.
+- Use plain TypeScript only for trivial data shapes, constants, config files, frontend React code, or small glue where Effect would add ceremony without improving failure handling.
+- Cloud VM backend logic must stay in Vercel route handlers and Effect services backed by Postgres.
+- Do not reintroduce Rivet or a raw actor protocol for Cloud VM unless a later architecture doc explicitly changes the control plane.
+- Production and staging Cloud VM Postgres use the Vercel Marketplace AWS Aurora PostgreSQL OIDC/RDS IAM path.
+- Runtime env names are `CMUX_DB_DRIVER=aws-rds-iam`, `AWS_ROLE_ARN`, `AWS_REGION`, `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE`.
+- Run production/staging migrations with `bun db:migrate:aws-rds-iam`; never run Drizzle migrations from Vercel build or route startup.
+- Local development keeps using the `CMUX_PORT`-derived Docker Postgres path from `bun dev`.
+- Cloud VM create pricing gates should use Stack Auth team payment items when enabled.
+- Postgres remains the source of truth for VM lifecycle, active VM limits, idempotency, and usage events.
+
+## Secrets
+
+Cloud VM build, test, and local dev scripts use provider secrets from `~/.secrets/cmux.env`.
+
+- `E2B_API_KEY`
+- `FREESTYLE_API_KEY`
+- R2 upload vars used by `web/scripts/build-cloud-vm-images.ts` when creating Freestyle snapshots
+
+Load them with:
+
+```bash
+set -a
+source ~/.secrets/cmux.env
+set +a
+```
+
+`~/.secrets/cmuxterm-dev.env` is for local Stack/web env and does not contain the provider build keys. `bun dev` sources `~/.secrets/cmux.env` first when present, then `~/.secrets/cmuxterm-dev.env` so cmuxterm-specific Stack settings override broader cmux secrets. The web dev loader still accepts the legacy `~/.secret/cmuxterm.env` and `~/.secrets/cmuxterm.env` paths while machines migrate.
+
+## Detailed references
+
+- Read [references/effect-boundaries.md](references/effect-boundaries.md) when shaping route handlers, services, typed errors, retries, or dependency injection.
+- Read [references/cloud-vm-control-plane.md](references/cloud-vm-control-plane.md) when touching VM lifecycle, migrations, Postgres, provider idempotency, or pricing gates.

--- a/.agents/skills/cmux-backend/agents/openai.yaml
+++ b/.agents/skills/cmux-backend/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Backend"
+  short_description: "Use Effect and Postgres-backed Cloud VM rules for backend work."
+  default_prompt: "Use this skill when editing cmux backend TypeScript, Vercel route handlers, Effect services, Cloud VM lifecycle code, provider integrations, database migrations, or pricing gates."

--- a/.agents/skills/cmux-backend/references/cloud-vm-control-plane.md
+++ b/.agents/skills/cmux-backend/references/cloud-vm-control-plane.md
@@ -1,0 +1,60 @@
+# Cloud VM Control Plane
+
+This reference expands the Cloud VM rules for lifecycle, persistence, migrations, and provider coordination.
+
+## Source of truth
+
+Postgres is the source of truth for:
+
+- VM lifecycle state
+- active VM limits
+- idempotency records
+- usage events
+- provider identifiers
+- team/account ownership
+
+Provider state is observed and reconciled, not treated as the canonical application state. If provider state and database state disagree, write code that makes the reconciliation explicit.
+
+## Vercel and Effect boundary
+
+Cloud VM backend logic lives in Vercel route handlers and Effect services. Route handlers should not become a raw actor protocol or long-running in-memory control plane. The durable state belongs in Postgres, and request-time workflows should be idempotent.
+
+Do not reintroduce Rivet or a raw actor protocol unless a later architecture document explicitly changes this control plane.
+
+## Migrations
+
+Production and staging migrations use:
+
+```bash
+bun db:migrate:aws-rds-iam
+```
+
+Never run Drizzle migrations from Vercel build or route startup. Build/startup migrations make deploy behavior non-deterministic and couple app availability to schema mutation.
+
+Local development keeps using the `CMUX_PORT`-derived Docker Postgres path from `bun dev`.
+
+## AWS RDS IAM runtime
+
+Production and staging Cloud VM Postgres should use the Vercel Marketplace AWS Aurora PostgreSQL OIDC/RDS IAM path with these runtime env names:
+
+- `CMUX_DB_DRIVER=aws-rds-iam`
+- `AWS_ROLE_ARN`
+- `AWS_REGION`
+- `PGHOST`
+- `PGPORT`
+- `PGUSER`
+- `PGDATABASE`
+
+Avoid inventing parallel env names for the same settings. Every new name creates another migration and deploy surface.
+
+## Pricing and active limits
+
+Cloud VM create pricing gates should use Stack Auth team payment items when enabled. Active limits and usage events should be persisted, not inferred from transient process memory.
+
+When changing create/start flows, verify:
+
+- idempotency prevents duplicate provider creates
+- team ownership is checked before provider allocation
+- active VM limits are enforced before expensive provider work
+- usage events are written exactly once for the lifecycle moment they represent
+- failed provider calls leave a recoverable database state

--- a/.agents/skills/cmux-backend/references/effect-boundaries.md
+++ b/.agents/skills/cmux-backend/references/effect-boundaries.md
@@ -1,0 +1,72 @@
+# Effect Boundaries
+
+This reference expands the backend TypeScript rules for route handlers, services, and scripts.
+
+## Route handler shape
+
+Route handlers should be shallow adapters. They should parse request input, construct or select the required Effect program, run it once at the boundary, and translate domain errors to HTTP responses. Keep workflow sequencing, retries, provider calls, and database updates outside the handler body.
+
+A good handler answers these questions quickly:
+
+- What input does the route accept?
+- Which Effect program performs the workflow?
+- Which typed errors map to expected HTTP statuses?
+- Which failures are unexpected defects?
+
+Avoid route handlers that interleave parsing, database writes, provider calls, and response construction. That shape makes retries and idempotency hard to audit.
+
+## Service shape
+
+Use Effect services when a workflow crosses an external boundary or has meaningful failure semantics:
+
+- provider APIs
+- database reads or writes
+- auth and team lookup
+- payment or quota checks
+- retries and timeout policy
+- telemetry and usage recording
+- idempotency claims
+
+Model expected failures as typed domain errors. Prefer names that describe the business failure, not the transport layer. For example, `VmLimitExceeded`, `ProviderCapacityUnavailable`, or `IdempotencyConflict` is more useful to callers than a raw `FetchError`.
+
+## Dependency shape
+
+Make service dependencies explicit. Do not hide important runtime dependencies behind globals when an Effect service can receive them as layer requirements.
+
+Good dependencies are concrete capabilities:
+
+- database client
+- provider client
+- auth/team service
+- clock or timeout policy
+- telemetry sink
+- idempotency repository
+
+Bad dependencies are broad ambient containers or untyped option bags that force every workflow to rediscover what it actually needs.
+
+## Plain TypeScript carve-out
+
+Plain TypeScript is fine for data-only code:
+
+- constants
+- schema declarations
+- config objects
+- frontend components
+- pure formatting helpers
+- tiny route glue with no external effects
+
+The point is not to use Effect everywhere. The point is to use it where explicit failure, dependency, retry, and cancellation semantics reduce real ambiguity.
+
+## Error mapping
+
+Expected domain errors should become clear HTTP responses. Unexpected defects should not be disguised as expected user errors.
+
+When adding a new route, check that:
+
+- invalid input maps to 400 or the existing validation status
+- auth and entitlement failures map to the existing auth/payment statuses
+- active-limit or quota failures are explicit
+- provider unavailability is distinguishable from a defect
+- idempotency conflicts return a deterministic response
+
+If a caller needs to retry, the response should make that practical.

--- a/.agents/skills/cmux-browser/SKILL.md
+++ b/.agents/skills/cmux-browser/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: cmux-browser
+description: End-user browser automation with cmux. Use when you need to open sites, interact with pages, wait for state changes, and extract data from cmux browser surfaces.
+---
+
+# Browser Automation with cmux
+
+Use this skill for browser tasks inside cmux webviews.
+
+## Core Workflow
+
+1. Open or target a browser surface.
+2. Verify navigation with `get url` before waiting or snapshotting.
+3. Snapshot (`--interactive`) to get fresh element refs.
+4. Act with refs (`click`, `fill`, `type`, `select`, `press`).
+5. Wait for state changes.
+6. Re-snapshot after DOM/navigation changes.
+
+```bash
+cmux --json browser open https://example.com
+# use returned surface ref, for example: surface:7
+
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "hello"
+cmux --json browser surface:7 click e2 --snapshot-after
+cmux browser surface:7 snapshot --interactive
+```
+
+## Surface Targeting
+
+```bash
+# identify current context
+cmux identify --json
+
+# open routed to a specific topology target
+cmux browser open https://example.com --workspace workspace:2 --window window:1 --json
+```
+
+Notes:
+- CLI output defaults to short refs (`surface:N`, `pane:N`, `workspace:N`, `window:N`).
+- UUIDs are still accepted on input; only request UUID output when needed (`--id-format uuids|both`).
+- Keep using one `surface:N` per task unless you intentionally switch.
+
+## Wait Support
+
+cmux supports wait patterns similar to agent-browser:
+
+```bash
+cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
+cmux browser <surface> wait --text "Success" --timeout-ms 10000
+cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser <surface> wait --load-state complete --timeout-ms 15000
+cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+```
+
+## Common Flows
+
+### Form Submit
+
+```bash
+cmux --json browser open https://example.com/signup
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "Jane Doe"
+cmux browser surface:7 fill e2 "jane@example.com"
+cmux --json browser surface:7 click e3 --snapshot-after
+cmux browser surface:7 wait --url-contains "/welcome" --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+```
+
+### Clear an Input
+
+```bash
+cmux browser surface:7 fill e11 "" --snapshot-after --json
+cmux browser surface:7 get value e11 --json
+```
+
+### Stable Agent Loop (Recommended)
+
+```bash
+# navigate -> verify -> wait -> snapshot -> action -> snapshot
+cmux browser surface:7 get url
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 snapshot --interactive
+cmux --json browser surface:7 click e5 --snapshot-after
+cmux browser surface:7 snapshot --interactive
+```
+
+If `get url` is empty or `about:blank`, navigate first instead of waiting on load state.
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full browser command mapping and quick syntax |
+| [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle and stale-ref troubleshooting |
+| [references/authentication.md](references/authentication.md) | Login/OAuth/2FA patterns and state save/load |
+| [references/authentication.md#saving-authentication-state](references/authentication.md#saving-authentication-state) | Save authenticated state right after login |
+| [references/session-management.md](references/session-management.md) | Multi-surface isolation and state persistence patterns |
+| [references/video-recording.md](references/video-recording.md) | Current recording status and practical alternatives |
+| [references/proxy-support.md](references/proxy-support.md) | Proxy behavior in WKWebView and workarounds |
+
+## Ready-to-Use Templates
+
+| Template | Description |
+|----------|-------------|
+| [templates/form-automation.sh](templates/form-automation.sh) | Snapshot/ref form fill loop |
+| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, save/load state |
+| [templates/capture-workflow.sh](templates/capture-workflow.sh) | Navigate + capture snapshots/screenshots |
+
+## Limits (WKWebView)
+
+These commands currently return `not_supported` because they rely on Chrome/CDP-only APIs not exposed by WKWebView:
+- viewport emulation
+- offline emulation
+- trace/screencast recording
+- network route interception/mocking
+- low-level raw input injection
+
+Use supported high-level commands (`click`, `fill`, `press`, `scroll`, `wait`, `snapshot`) instead.
+
+## Troubleshooting
+
+### `js_error` on `snapshot --interactive` or `eval`
+
+Some complex pages can reject or break the JavaScript used for rich snapshots and ad-hoc evaluation.
+
+Recovery steps:
+
+```bash
+cmux browser surface:7 get url
+cmux browser surface:7 get text body
+cmux browser surface:7 get html body
+```
+
+- Use `get url` first so you know whether the page actually navigated.
+- Fall back to `get text body` or `get html body` when `snapshot --interactive` or `eval` returns `js_error`.
+- If the page is still failing, navigate to a simpler intermediate page, then retry the task from there.

--- a/.agents/skills/cmux-browser/agents/openai.yaml
+++ b/.agents/skills/cmux-browser/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Browser"
+  short_description: "Automate cmux webview surfaces with snapshot/ref workflows."
+  default_prompt: "Use this skill for browser automation via cmux CLI: identify target surface, snapshot interactive refs, perform actions, wait for state changes, and re-snapshot to avoid stale refs."

--- a/.agents/skills/cmux-browser/references/authentication.md
+++ b/.agents/skills/cmux-browser/references/authentication.md
@@ -1,0 +1,122 @@
+# Authentication Patterns
+
+Login flows, session persistence, OAuth, and 2FA patterns for cmux browser surfaces.
+
+**Related**: [session-management.md](session-management.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Basic Login Flow](#basic-login-flow)
+- [Saving Authentication State](#saving-authentication-state)
+- [Restoring Authentication](#restoring-authentication)
+- [OAuth / SSO Flows](#oauth--sso-flows)
+- [Two-Factor Authentication](#two-factor-authentication)
+- [Cookie-Based Auth](#cookie-based-auth)
+- [Token Refresh Handling](#token-refresh-handling)
+- [Security Best Practices](#security-best-practices)
+
+## Basic Login Flow
+
+```bash
+cmux browser open https://app.example.com/login --json
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+
+cmux browser surface:7 snapshot --interactive
+# [ref=e1] email, [ref=e2] password, [ref=e3] submit
+
+cmux browser surface:7 fill e1 "user@example.com"
+cmux browser surface:7 fill e2 "$APP_PASSWORD"
+cmux browser surface:7 click e3 --snapshot-after --json
+cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 20000
+```
+
+## Saving Authentication State
+
+After logging in, save state for reuse:
+
+```bash
+cmux browser surface:7 state save ./auth-state.json
+```
+
+State includes cookies, localStorage, sessionStorage, and open tab metadata for that surface.
+
+## Restoring Authentication
+
+```bash
+cmux browser open https://app.example.com --json
+cmux browser surface:8 state load ./auth-state.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+cmux browser surface:8 snapshot --interactive
+```
+
+## OAuth / SSO Flows
+
+```bash
+cmux browser open https://app.example.com/auth/google --json
+cmux browser surface:7 wait --url-contains "accounts.google.com" --timeout-ms 30000
+cmux browser surface:7 snapshot --interactive
+
+cmux browser surface:7 fill e1 "user@gmail.com"
+cmux browser surface:7 click e2 --snapshot-after --json
+
+cmux browser surface:7 wait --url-contains "app.example.com" --timeout-ms 45000
+cmux browser surface:7 state save ./oauth-state.json
+```
+
+## Two-Factor Authentication
+
+```bash
+cmux browser open https://app.example.com/login --json
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 fill e1 "user@example.com"
+cmux browser surface:7 fill e2 "$APP_PASSWORD"
+cmux browser surface:7 click e3
+
+# complete 2FA manually in the webview, then:
+cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 120000
+cmux browser surface:7 state save ./2fa-state.json
+```
+
+## Cookie-Based Auth
+
+```bash
+cmux browser surface:7 cookies set session_token "abc123xyz"
+cmux browser surface:7 goto https://app.example.com/dashboard
+```
+
+## Token Refresh Handling
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_FILE="./auth-state.json"
+SURFACE="surface:7"
+
+if [ -f "$STATE_FILE" ]; then
+  cmux browser "$SURFACE" state load "$STATE_FILE"
+fi
+
+cmux browser "$SURFACE" goto https://app.example.com/dashboard
+URL=$(cmux browser "$SURFACE" get url)
+
+if printf '%s' "$URL" | grep -q '/login'; then
+  cmux browser "$SURFACE" snapshot --interactive
+  cmux browser "$SURFACE" fill e1 "$APP_USERNAME"
+  cmux browser "$SURFACE" fill e2 "$APP_PASSWORD"
+  cmux browser "$SURFACE" click e3
+  cmux browser "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 20000
+  cmux browser "$SURFACE" state save "$STATE_FILE"
+fi
+```
+
+## Security Best Practices
+
+1. Never commit state files (they include auth tokens).
+2. Use environment variables for credentials.
+3. Clear state/cookies after sensitive tasks:
+
+```bash
+cmux browser surface:7 cookies clear
+rm -f ./auth-state.json
+```

--- a/.agents/skills/cmux-browser/references/commands.md
+++ b/.agents/skills/cmux-browser/references/commands.md
@@ -1,0 +1,108 @@
+# Command Reference (cmux Browser)
+
+This maps common `agent-browser` usage to `cmux browser` usage.
+
+## Direct Equivalents
+
+- `agent-browser open <url>` -> `cmux browser open <url>`
+- `agent-browser goto|navigate <url>` -> `cmux browser <surface> goto|navigate <url>`
+- `agent-browser snapshot -i` -> `cmux browser <surface> snapshot --interactive`
+- `agent-browser click <ref>` -> `cmux browser <surface> click <ref>`
+- `agent-browser fill <ref> <text>` -> `cmux browser <surface> fill <ref> <text>`
+- `agent-browser type <ref> <text>` -> `cmux browser <surface> type <ref> <text>`
+- `agent-browser select <ref> <value>` -> `cmux browser <surface> select <ref> <value>`
+- `agent-browser get text <ref>` -> `cmux browser <surface> get text <ref-or-selector>`
+- `agent-browser get url` -> `cmux browser <surface> get url`
+- `agent-browser get title` -> `cmux browser <surface> get title`
+
+## Core Command Groups
+
+### Navigation
+
+```bash
+cmux browser open <url>                        # opens in caller's workspace (uses CMUX_WORKSPACE_ID)
+cmux browser open <url> --workspace <id|ref>   # opens in a specific workspace
+cmux browser <surface> goto <url>
+cmux browser <surface> back|forward|reload
+cmux browser <surface> get url|title
+```
+
+> **Workspace context:** `browser open` targets the workspace of the terminal where the command is run (via `CMUX_WORKSPACE_ID`), even if a different workspace is currently focused. Use `--workspace` to override.
+
+### Snapshot and Inspection
+
+```bash
+cmux browser <surface> snapshot --interactive
+cmux browser <surface> snapshot --interactive --compact --max-depth 3
+cmux browser <surface> get text body
+cmux browser <surface> get html body
+cmux browser <surface> get value "#email"
+cmux browser <surface> get attr "#email" --attr placeholder
+cmux browser <surface> get count ".row"
+cmux browser <surface> get box "#submit"
+cmux browser <surface> get styles "#submit" --property color
+cmux browser <surface> eval '<js>'
+```
+
+### Interaction
+
+```bash
+cmux browser <surface> click|dblclick|hover|focus <selector-or-ref>
+cmux browser <surface> fill <selector-or-ref> [text]   # empty text clears
+cmux browser <surface> type <selector-or-ref> <text>
+cmux browser <surface> press|keydown|keyup <key>
+cmux browser <surface> select <selector-or-ref> <value>
+cmux browser <surface> check|uncheck <selector-or-ref>
+cmux browser <surface> scroll [--selector <css>] [--dx <n>] [--dy <n>]
+```
+
+### Wait
+
+```bash
+cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
+cmux browser <surface> wait --text "Done" --timeout-ms 10000
+cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser <surface> wait --load-state complete --timeout-ms 15000
+cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+```
+
+### Session/State
+
+```bash
+cmux browser <surface> cookies get|set|clear ...
+cmux browser <surface> storage local|session get|set|clear ...
+cmux browser <surface> tab list|new|switch|close ...
+cmux browser <surface> state save|load <path>
+```
+
+### Diagnostics
+
+```bash
+cmux browser <surface> console list|clear
+cmux browser <surface> errors list|clear
+cmux browser <surface> highlight <selector>
+cmux browser <surface> screenshot
+cmux browser <surface> download wait --timeout-ms 10000
+```
+
+## Agent Reliability Tips
+
+- Use `--snapshot-after` on mutating actions to return a fresh post-action snapshot.
+- Re-snapshot after navigation, modal open/close, or major DOM changes.
+- Prefer short handles in outputs by default (`surface:N`, `pane:N`, `workspace:N`, `window:N`).
+- Use `--id-format both` only when a UUID must be logged/exported.
+
+## Known WKWebView Gaps (`not_supported`)
+
+- `browser.viewport.set`
+- `browser.geolocation.set`
+- `browser.offline.set`
+- `browser.trace.start|stop`
+- `browser.network.route|unroute|requests`
+- `browser.screencast.start|stop`
+- `browser.input_mouse|input_keyboard|input_touch`
+
+See also:
+- [snapshot-refs.md](snapshot-refs.md)
+- [authentication.md](authentication.md)
+- [session-management.md](session-management.md)

--- a/.agents/skills/cmux-browser/references/proxy-support.md
+++ b/.agents/skills/cmux-browser/references/proxy-support.md
@@ -1,0 +1,37 @@
+# Proxy Support
+
+How proxy behavior works for cmux browser automation.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Current Behavior](#current-behavior)
+- [What Is Not Exposed via CLI](#what-is-not-exposed-via-cli)
+- [Workarounds](#workarounds)
+- [Verification](#verification)
+
+## Current Behavior
+
+cmux browser uses WKWebView networking. Proxy behavior follows macOS/system networking and app process environment.
+
+## What Is Not Exposed via CLI
+
+There is currently no first-class `cmux browser proxy ...` command for per-surface proxy routing.
+
+Why: WKWebView does not provide CDP-style per-context proxy controls equivalent to Chrome automation stacks.
+
+## Workarounds
+
+1. Configure system/network-level proxy for the environment where cmux runs.
+2. Route traffic through an upstream gateway you control.
+3. Validate behavior with explicit IP checks.
+
+## Verification
+
+```bash
+cmux browser open https://httpbin.org/ip --json
+cmux browser surface:7 get text body
+```
+
+Compare returned IP against expected proxy egress.

--- a/.agents/skills/cmux-browser/references/session-management.md
+++ b/.agents/skills/cmux-browser/references/session-management.md
@@ -1,0 +1,94 @@
+# Session Management
+
+cmux uses isolated browser contexts per surface. Treat each browser surface as its own session.
+
+**Related**: [authentication.md](authentication.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Surface-Based Sessions](#surface-based-sessions)
+- [Isolation Properties](#isolation-properties)
+- [State Persistence](#state-persistence)
+- [Common Patterns](#common-patterns)
+- [Cleanup](#cleanup)
+- [Best Practices](#best-practices)
+
+## Surface-Based Sessions
+
+```bash
+# session A
+cmux browser open https://app.example.com/login --json
+# -> surface:7
+
+# session B
+cmux browser open https://example.com --json
+# -> surface:8
+
+cmux browser surface:7 get url
+cmux browser surface:8 get url
+```
+
+## Isolation Properties
+
+Each surface has independent:
+- cookies
+- localStorage/sessionStorage
+- tab list and active tab
+- navigation history
+
+## State Persistence
+
+### Save State
+
+```bash
+cmux browser surface:7 state save /tmp/auth-state.json
+```
+
+### Load State
+
+```bash
+cmux browser surface:8 state load /tmp/auth-state.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+```
+
+## Common Patterns
+
+### Reuse Auth Across New Surface
+
+```bash
+cmux browser open https://app.example.com/login --json
+# login on surface:7 ...
+cmux browser surface:7 state save /tmp/auth.json
+
+cmux browser open https://app.example.com --json
+# assume surface:8
+cmux browser surface:8 state load /tmp/auth.json
+cmux browser surface:8 goto https://app.example.com/dashboard
+```
+
+### Parallel Multi-Site Tasks
+
+```bash
+cmux browser open https://site-a.example --json
+cmux browser open https://site-b.example --json
+cmux browser open https://site-c.example --json
+
+cmux browser surface:11 get text body > /tmp/a.txt
+cmux browser surface:12 get text body > /tmp/b.txt
+cmux browser surface:13 get text body > /tmp/c.txt
+```
+
+## Cleanup
+
+```bash
+cmux close-surface --surface surface:7
+cmux close-surface --surface surface:8
+rm -f /tmp/auth-state.json
+```
+
+## Best Practices
+
+1. Name/log surfaces in your script output so actions stay attributable.
+2. Keep one task per surface to avoid ref churn.
+3. Save state after successful auth milestones.
+4. Re-snapshot after switching tabs/pages inside a surface.

--- a/.agents/skills/cmux-browser/references/snapshot-refs.md
+++ b/.agents/skills/cmux-browser/references/snapshot-refs.md
@@ -1,0 +1,88 @@
+# Snapshot and Refs
+
+Element refs from snapshots make browser automation compact and reliable.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [How Refs Work](#how-refs-work)
+- [The Snapshot Command](#the-snapshot-command)
+- [Using Refs](#using-refs)
+- [Ref Lifecycle](#ref-lifecycle)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## How Refs Work
+
+Classic flow:
+
+```text
+full DOM/HTML -> selector guessing -> action
+```
+
+cmux flow:
+
+```text
+snapshot -> refs (e1/e2/...) -> direct action
+```
+
+## The Snapshot Command
+
+```bash
+cmux browser surface:7 snapshot
+cmux browser surface:7 snapshot --interactive
+cmux browser surface:7 snapshot --interactive --compact --max-depth 3
+```
+
+## Using Refs
+
+```bash
+cmux browser surface:7 click e6
+cmux browser surface:7 fill e10 "user@example.com"
+cmux browser surface:7 fill e11 "password123"
+cmux browser surface:7 click e12
+```
+
+## Ref Lifecycle
+
+Refs are invalidated when page structure changes.
+
+```bash
+cmux browser surface:7 snapshot --interactive
+# e1 is "Next"
+
+cmux browser surface:7 click e1
+
+# page changed, take a fresh snapshot
+cmux browser surface:7 snapshot --interactive
+```
+
+## Best Practices
+
+1. Snapshot before interacting.
+2. Re-snapshot after navigation/modal/open-close flows.
+3. Use `--snapshot-after` on mutating actions.
+4. Scope snapshots with `--selector` for very large pages.
+
+## Troubleshooting
+
+### not_found / stale ref
+
+```bash
+cmux browser surface:7 snapshot --interactive
+```
+
+### Element missing due visibility/timing
+
+```bash
+cmux browser surface:7 wait --selector "#target" --timeout-ms 10000
+cmux browser surface:7 scroll --dy 400
+cmux browser surface:7 snapshot --interactive
+```
+
+### Too many elements
+
+```bash
+cmux browser surface:7 snapshot --selector "form#checkout" --interactive
+```

--- a/.agents/skills/cmux-browser/references/video-recording.md
+++ b/.agents/skills/cmux-browser/references/video-recording.md
@@ -1,0 +1,52 @@
+# Video Recording
+
+Status and alternatives for capturing browser automation evidence in cmux.
+
+**Related**: [commands.md](commands.md), [SKILL.md](../SKILL.md)
+
+## Contents
+
+- [Current Status](#current-status)
+- [Recommended Alternatives](#recommended-alternatives)
+- [Use Cases](#use-cases)
+- [Best Practices](#best-practices)
+
+## Current Status
+
+`cmux browser` currently does not expose a built-in video recording command.
+
+Why: cmux browser automation runs on WKWebView, and the agent-browser style recording pipeline is Chrome/CDP-specific.
+
+## Recommended Alternatives
+
+### 1. Step Screenshots
+
+```bash
+cmux browser surface:7 screenshot > /tmp/step1.b64
+cmux browser surface:7 click e3 --snapshot-after --json
+cmux browser surface:7 screenshot > /tmp/step2.b64
+```
+
+### 2. Snapshot Timeline
+
+```bash
+cmux browser surface:7 snapshot --interactive > /tmp/snap-1.txt
+cmux browser surface:7 click e3 --snapshot-after --json > /tmp/action-1.json
+cmux browser surface:7 snapshot --interactive > /tmp/snap-2.txt
+```
+
+### 3. macOS Window Capture (external)
+
+Use an external screen recorder if full-motion capture is required.
+
+## Use Cases
+
+- Debug flaky browser automation.
+- Produce artifacts for CI logs.
+- Document flow changes between releases.
+
+## Best Practices
+
+1. Capture snapshot before and after each mutating action.
+2. Add `--snapshot-after` on clicks/fills/types that change state.
+3. Keep artifacts grouped by timestamp/run id.

--- a/.agents/skills/cmux-browser/templates/authenticated-session.sh
+++ b/.agents/skills/cmux-browser/templates/authenticated-session.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SURFACE="${1:-surface:1}"
+STATE_FILE="${2:-./auth-state.json}"
+DASHBOARD_URL="${3:-https://app.example.com/dashboard}"
+
+if [ -f "$STATE_FILE" ]; then
+  cmux browser "$SURFACE" state load "$STATE_FILE"
+fi
+
+cmux browser "$SURFACE" goto "$DASHBOARD_URL"
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" snapshot --interactive
+
+echo "If redirected to login, complete login flow then run:"
+echo "  cmux browser $SURFACE state save $STATE_FILE"

--- a/.agents/skills/cmux-browser/templates/capture-workflow.sh
+++ b/.agents/skills/cmux-browser/templates/capture-workflow.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SURFACE="${1:-surface:1}"
+OUT_DIR="${2:-./browser-artifacts}"
+mkdir -p "$OUT_DIR"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+cmux browser "$SURFACE" snapshot --interactive > "$OUT_DIR/snapshot-$TS.txt"
+cmux browser "$SURFACE" screenshot > "$OUT_DIR/screenshot-$TS.b64"
+
+echo "Wrote: $OUT_DIR/snapshot-$TS.txt"
+echo "Wrote: $OUT_DIR/screenshot-$TS.b64"

--- a/.agents/skills/cmux-browser/templates/form-automation.sh
+++ b/.agents/skills/cmux-browser/templates/form-automation.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${1:-https://example.com/form}"
+SURFACE="${2:-surface:1}"
+
+cmux browser "$SURFACE" goto "$URL"
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" snapshot --interactive
+
+echo "Now run fill/click commands using refs from the snapshot above."

--- a/.agents/skills/cmux-custom-sidebar/SKILL.md
+++ b/.agents/skills/cmux-custom-sidebar/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cmux-custom-sidebar
+description: "Build a custom cmux sidebar from a plain-language request. Use when the user asks for a custom sidebar, a sidebar that shows their workspaces/tabs/PRs/clock, a vibe-coded sidebar, or anything involving files in ~/.config/cmux/sidebars/. Covers authoring the interpreted SwiftUI-style file, enabling the beta flag, selecting it, and iterating with hot reload."
+---
+
+# cmux Custom Sidebar
+
+cmux renders custom sidebars from a small SwiftUI-style file at runtime: no Xcode, no build step, no signing. The file hot-reloads on save, binds to live cmux state (workspaces, tabs, git, PRs, clock), and can run real cmux commands on tap.
+
+The person asking is usually describing a result ("a sidebar that shows my workspaces and lets me jump between them"), not an implementation. Turn that into a clean, native-looking sidebar and make the engineering decisions for them. Do not ask them about SwiftUI, files, or syntax.
+
+## Full reference
+
+This skill is the workflow summary. The complete authoring contract (every supported view, modifier, language feature, and data field) is one command away; read it before writing a non-trivial sidebar:
+
+```bash
+cmux docs sidebars
+curl -fsSL https://raw.githubusercontent.com/manaflow-ai/cmux/main/docs/custom-sidebars.md
+```
+
+## Workflow
+
+1. **Enable the beta** (once). Custom sidebars are behind Settings → Beta features → Custom sidebars (`customSidebars.beta.enabled`). If a written sidebar does not appear in the picker, this flag is the first thing to check.
+2. **Write a named file.** The name becomes the menu label; use short kebab-case:
+   ```
+   ~/.config/cmux/sidebars/<name>.swift
+   ```
+   The file is a single SwiftUI-style view expression (no `struct`, no `var body`, no imports). A `.json` variant exists for static layouts; prefer `.swift` for anything dynamic.
+3. **Validate and select it:**
+   ```bash
+   cmux sidebar validate <name>   # parse/interpret check with real data shapes
+   cmux sidebar select <name>     # switch the sidebar to it
+   ```
+   The user can also pick it manually: right-click the sidebar toggle button.
+4. **Iterate.** Saving the file hot-reloads the sidebar in place (`cmux sidebar reload` forces it). Look at the result, fix what looks off, and verify rows show real data and taps do the right thing before declaring it done.
+
+## Authoring rules
+
+- **Default to live data.** Bind to the `workspaces` context instead of hard-coding text so the sidebar stays correct on its own.
+- **Make it interactive by default.** Rows that represent something openable should run the matching `cmux(...)` action on tap. A list that just displays text is rarely what they wanted.
+- **Prefer `Reorderable` for workspace-like lists.** It gives persisted drag-and-drop reordering for free.
+- **Keep it native and uncluttered:** a title, a divider, then the content.
+- **Cap long lists** (`.prefix(20)`, filter/sort before rendering). The sidebar re-evaluates about once a second; do not render hundreds of rows.
+- **Stay inside the supported subset.** Unsupported syntax is skipped gracefully (never crashes), but choose the closest supported approach rather than shipping a half-blank sidebar.
+
+## Quick start
+
+```bash
+cat > ~/.config/cmux/sidebars/mine.swift <<'SWIFT'
+VStack(alignment: .leading, spacing: 8) {
+    Text("My sidebar").font(.title3).bold()
+    Text(clock.time).font(.caption).foregroundColor(.secondary)
+    Divider()
+    Reorderable(workspaces, move: "workspace.reorder") { w in
+        Button(action: { cmux("workspace.select", workspace_id: w.id) }) {
+            HStack {
+                Text(w.selected ? "●" : "○").foregroundColor(w.selected ? "#FF8800" : .secondary)
+                Text(w.title)
+                Spacer()
+            }.padding(4)
+        }
+    }
+}
+SWIFT
+cmux sidebar validate mine && cmux sidebar select mine
+```
+
+## Live data context (read-only, refreshes ~1s)
+
+- `workspaces`: array with `id`, `title`, `selected`, `pinned`, `index`, `directory`, `ports` + `portCount`, `unread`, `tabs` + `tabCount`; plus, when present: `description`, `color`, `branch` + `dirty`, `pr` / `prs` (`{number, label, url, status, stale, branch}`), `progress` (`{value, label}`), `latestMessage`, `latestPrompt`, `latestAt`, `remote` (`{target, state, connected}`).
+- `workspaces[i].tabs`: `id`, `title`, `focused`, `pinned`; plus `directory`, `branch` + `dirty`, `ports` when available.
+- `clock`: `{time, hour, minute, second, weekday, epoch}`.
+- Scalars: `workspaceCount`, `selectedTitle`, `selectedId`, `unreadTotal`.
+
+Optional fields are omitted when absent; guard with `if let b = w.branch { ... }` or `w.pr != nil ? ... : ...`.
+
+## Actions
+
+A button or `.onTapGesture` body calls `cmux("<method>", param: value)`, dispatched through the same surface as the `cmux` CLI. Common methods: `workspace.select` (`workspace_id`), `surface.focus` (`surface_id`), `workspace.reorder` (`workspace_id` + `index`). `openURL("https://...")` opens links. Discover the full command surface with `cmux docs api`.
+
+## Supported subset at a glance
+
+Containers: stacks (incl. lazy), `Group`, `List`, `Section`, grids, `ViewThatFits`, `ScrollView`, `HSplitView` (two resizable columns). Content: `Text`, `Label`, `Image(systemName:)`, `Button` (title and label form), `Menu`, `ProgressView`, `Gauge`, `Spacer`, `Divider`, shapes, gradients via `.background`. Modifiers: full typography set, colors as hex strings or tokens, `.padding`/`.frame`/layout, `.background`/`.overlay`/`.mask`/`.contextMenu` with arbitrary nested views, shadows/borders/opacity/effects, `.onTapGesture`, `.help`, `.disabled`. Language: `let`, user `func` helpers, `for`/`ForEach`, `if/else`, ternary, string interpolation, arithmetic, array methods (`filter`/`map`/`sorted`/`prefix`/...), string and number formatting.
+
+Not yet supported (write the natural Swift anyway; it degrades gracefully): `@State` and input controls (`TextField`, `Toggle`, `Slider`, `Picker`), custom `struct`/`View` definitions, navigation (`sheet`/`popover`), `AsyncImage`. Two-way editing does not work yet; taps that run `cmux(...)` do.
+
+## Troubleshooting
+
+- Sidebar missing from the right-click picker: the beta flag is off, or the file is not directly under `~/.config/cmux/sidebars/`.
+- Blank or partial render: run `cmux sidebar validate <name>`; errors show inline in the sidebar with the failing location. A broken save keeps the last working render on screen, so re-save after fixing.
+- Rows not tappable: wrap the row in `Button(action: { cmux(...) }) { ... }` or add `.onTapGesture { cmux(...) }`.
+- Reorder not persisting: use `Reorderable(data, move: "workspace.reorder")`, not `List`/`.onMove`/`.draggable`.

--- a/.agents/skills/cmux-customization/SKILL.md
+++ b/.agents/skills/cmux-customization/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: cmux-customization
+description: "Customize cmux for an end user. Use when changing cmux.json actions, custom commands, workspace layouts, plus-button behavior, surface tab bar buttons, Command Palette entries, Dock controls, sidebar and app settings, shortcuts, notifications, browser routing, examples-library presets, or Ghostty-backed terminal preferences."
+---
+
+# cmux Customization
+
+Use this skill for user-facing cmux customization. Keep the user's config intact, prefer schema-backed edits, and validate before reporting completion.
+
+## What Can Be Customized
+
+- Custom actions: define reusable `actions` in `cmux.json`. Actions can appear in Cmd+Shift+P, surface tab bars, shortcuts, and the plus-button right-click menu.
+- New workspace button: set `ui.newWorkspace.action` to replace the normal plus-button click, and `ui.newWorkspace.contextMenu` to control right-click actions. `ui.newWorkspace.rightClick` is accepted as an alias, but new examples should use `contextMenu`.
+- Surface tab bar buttons: set `ui.surfaceTabBar.buttons` to replace the default tab bar buttons. Include built-in IDs such as `cmux.newTerminal`, `cmux.newBrowser`, `cmux.splitRight`, and `cmux.splitDown` only when they should stay visible.
+- Workflows and layouts: use `commands` with workspace definitions to open a worktree, multiple checkouts, local services, browser previews, or SSH sessions in a deliberate split layout.
+- Dock controls: create `.cmux/dock.json` or `~/.config/cmux/dock.json` for right-sidebar terminal controls such as logs, test watchers, git TUIs, dev servers, queues, or `cmux feed tui --opentui`.
+- Sidebar and app behavior: use `cmux-settings` for supported settings such as appearance, sidebar display, notification behavior, browser routing, automation, shortcuts, and new-workspace placement.
+- Workspace metadata: use the cmux CLI or `cmux-workspace` for workspace names, descriptions, colors, read state, and sidebar metadata updates.
+- Feed and notifications: use `cmux hooks setup` for Feed event sources, notification settings for delivery behavior, and notification hooks in `cmux.json` for filtering or post-processing banners.
+- Team presets and examples: use project-local `.cmux/cmux.json` and `.cmux/dock.json` to share worktree, SSH, review, dev, CI, and docs workspace patterns with a repo.
+- Import, export, and reset: back up the current config, apply the smallest diff, validate it, and keep a rollback path for user-owned customizations.
+- Terminal behavior: use Ghostty config for fonts, themes, cursor style, copy-on-select, shell integration, terminal keybindings, and terminal rendering.
+
+## Choose the Right Surface
+
+- cmux app preferences: use `cmux-settings` for global `~/.config/cmux/cmux.json` settings such as appearance, sidebar, notifications, browser behavior, automation, and shortcuts.
+- Custom actions, workspace layouts, tab bar buttons, plus-button behavior, and Command Palette entries: edit `~/.config/cmux/cmux.json` globally or `.cmux/cmux.json` in the project. Project-local actions and commands override global entries with the same ID or name.
+- Dock controls: edit `.cmux/dock.json` in the project or `~/.config/cmux/dock.json` globally. Run `cmux docs dock` when available.
+- Terminal rendering and terminal keybindings: use Ghostty config, usually `~/.config/ghostty/config`. This includes fonts, cursor style, copy-on-select, shell integration, themes, and terminal keybindings.
+- Project-specific behavior: prefer `.cmux/cmux.json` in the project so actions, commands, UI action wiring, and notification hooks travel with the repo. Do not put global app preferences there.
+
+If a request can be handled by Ghostty config, say that and use Ghostty config instead of inventing cmux UI settings.
+
+## Examples Library
+
+For reusable patterns such as worktree agents, full-stack dev layouts, SSH
+devboxes, PR review workspaces, docs workspaces, quick agent tab buttons, and
+CI watches, read `references/examples.md`. Load it when the user asks for examples, presets,
+templates, starter configs, or a known workflow shape.
+
+## Workflow
+
+1. Inspect existing config before editing.
+
+   ```bash
+   test -f ~/.config/cmux/cmux.json && sed -n '1,220p' ~/.config/cmux/cmux.json
+   test -f .cmux/cmux.json && sed -n '1,220p' .cmux/cmux.json
+   ```
+
+2. Pick global or project-local scope. Ask only when the choice changes behavior meaningfully. Default to project-local for repo-specific commands and global for app preferences.
+3. Before editing, back up the target file when it already exists:
+
+   ```bash
+   stamp="$(date +%Y%m%d-%H%M%S)"
+   test -f ~/.config/cmux/cmux.json && cp -p ~/.config/cmux/cmux.json ~/.config/cmux/cmux.json."$stamp".bak
+   test -f .cmux/cmux.json && cp -p .cmux/cmux.json .cmux/cmux.json."$stamp".bak
+   ```
+
+   Use the applicable path only. Do not create a backup for a missing file.
+4. For app settings and cmux-owned shortcuts, use the settings helper from the installed skill or checkout:
+
+   ```bash
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings list-supported
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings set browser.openTerminalLinksInCmuxBrowser true
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings validate
+   ```
+
+   If the user installed with `skills.sh`, use `~/.codex/skills/cmux-settings/scripts/cmux-settings` instead.
+5. For actions, UI wiring, workspace layouts, notification hooks, and Dock controls, edit JSONC or JSON carefully. Preserve unrelated sections such as `vault`, `rightSidebar`, `commands`, `actions`, `ui`, and `notifications`.
+6. Reload config after successful edits:
+
+   ```bash
+   cmux reload-config
+   ```
+
+7. Verify the configured entrypoint exists. For shortcuts, read back the binding. For custom actions, confirm the action ID and where it should appear.
+
+## Common Patterns
+
+Add a Command Palette action that opens Codex in a new tab. It will appear in Cmd+Shift+P unless `palette` is false:
+
+```json
+{
+  "actions": {
+    "codex-new-tab": {
+      "type": "agent",
+      "agent": "codex",
+      "title": "Codex",
+      "subtitle": "Start Codex in this workspace",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    }
+  }
+}
+```
+
+Replace the plus-button click and define the plus-button right-click menu.
+This is the pattern for "bring your own worktree, multiple checkouts, or SSH
+setup". The `workspaceCommand` action ID is `worktree-agents`, and its
+`commandName` must match a command named `Worktree Agents` in the same config:
+
+```json
+{
+  "actions": {
+    "worktree-agents": {
+      "type": "workspaceCommand",
+      "title": "Worktree Agents",
+      "commandName": "Worktree Agents",
+      "icon": { "type": "symbol", "name": "folder.badge.plus" }
+    }
+  },
+  "ui": {
+    "newWorkspace": {
+      "action": "worktree-agents",
+      "contextMenu": [
+        { "action": "worktree-agents", "title": "Worktree Agents" },
+        { "type": "separator" },
+        { "action": "cmux.newTerminal", "title": "New Terminal" },
+        { "action": "cmux.newBrowser", "title": "New Browser" }
+      ]
+    }
+  },
+  "commands": [
+    {
+      "name": "Worktree Agents",
+      "description": "Create a worktree and open agents inside it",
+      "workspace": {
+        "name": "Worktree Agents",
+        "cwd": "../worktrees/my-feature",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Codex", "command": "codex" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "SSH", "command": "ssh devbox" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Add a project workspace layout:
+
+```json
+{
+  "commands": [
+    {
+      "name": "dev",
+      "workspace": {
+        "name": "Dev",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            { "pane": { "surfaces": [{ "type": "terminal", "command": "bun dev" }] } },
+            { "pane": { "surfaces": [{ "type": "browser", "url": "http://localhost:3000" }] } }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+Replace surface tab bar buttons:
+
+```json
+{
+  "ui": {
+    "surfaceTabBar": {
+      "buttons": [
+        "cmux.newTerminal",
+        "cmux.newBrowser",
+        {
+          "action": "codex-new-tab",
+          "title": "Codex",
+          "icon": { "type": "symbol", "name": "terminal" }
+        }
+      ]
+    }
+  }
+}
+```
+
+Add project Dock controls:
+
+```json
+{
+  "controls": [
+    {
+      "id": "git",
+      "title": "Git",
+      "command": "lazygit",
+      "cwd": ".",
+      "height": 300
+    },
+    {
+      "id": "feed",
+      "title": "Feed",
+      "command": "cmux feed tui --opentui",
+      "height": 260
+    }
+  ]
+}
+```
+
+## Validation
+
+- App settings: run `cmux-settings validate`.
+- JSONC shape: keep valid JSONC and avoid duplicate keys.
+- Dock JSON: parse `.cmux/dock.json` or `~/.config/cmux/dock.json` with a JSON parser before reporting completion.
+- Runtime reload: run `cmux reload-config` when the CLI is available.
+- User-facing action: confirm the action title, shortcut, plus-button behavior, context-menu entry, or tab bar placement the user asked for.
+
+## Rules
+
+- Do not overwrite whole top-level config sections unless you own the full section.
+- Do not store secrets directly in actions, commands, or prompts. Use environment variables or the user's secret manager.
+- Do not use app/runtime sleeps or timing workarounds in generated commands.
+- Do not add a cmux setting for behavior Ghostty already owns.
+- Keep labels short enough for menus, buttons, and the Command Palette.

--- a/.agents/skills/cmux-customization/agents/openai.yaml
+++ b/.agents/skills/cmux-customization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Customization"
+  short_description: "Customize cmux actions, UI, layouts, and presets."
+  default_prompt: "Use $cmux-customization to pick an examples-library preset, wire it into cmux.json, and validate the cmux config."

--- a/.agents/skills/cmux-customization/references/examples.md
+++ b/.agents/skills/cmux-customization/references/examples.md
@@ -1,0 +1,338 @@
+# cmux Customization Examples
+
+Use these examples as starting points. Merge only the relevant top-level keys
+into the target config file named above each code block. Unlabeled JSON examples
+target `cmux.json`. Preserve unrelated sections, then run `cmux reload-config`
+when available.
+
+Prefer project-local `.cmux/cmux.json` for team workflows and global
+`~/.config/cmux/cmux.json` for personal app preferences.
+
+## Worktree Agents
+
+Use this when the user wants the plus button to open a worktree or checkout
+layout, and right-click to offer alternate starters.
+
+```json
+{
+  "actions": {
+    "worktree-agents": {
+      "type": "workspaceCommand",
+      "title": "Worktree Agents",
+      "commandName": "Worktree Agents",
+      "icon": { "type": "symbol", "name": "folder.badge.plus" }
+    }
+  },
+  "ui": {
+    "newWorkspace": {
+      "action": "worktree-agents",
+      "contextMenu": [
+        { "action": "worktree-agents", "title": "Worktree Agents" },
+        { "type": "separator" },
+        { "action": "cmux.newTerminal", "title": "New Terminal" },
+        { "action": "cmux.newBrowser", "title": "New Browser" }
+      ]
+    }
+  },
+  "commands": [
+    {
+      "name": "Worktree Agents",
+      "workspace": {
+        "name": "Worktree Agents",
+        "cwd": "../worktrees/my-feature",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Codex", "command": "codex" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "Claude", "command": "claude" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Full-Stack Dev
+
+Use this when a repo needs terminals, browser preview, and persistent Dock
+controls for repeated local development.
+
+`.cmux/cmux.json`:
+
+```json
+{
+  "commands": [
+    {
+      "name": "Full-Stack Dev",
+      "workspace": {
+        "name": "Dev",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.55,
+          "children": [
+            {
+              "direction": "vertical",
+              "children": [
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Web", "command": "bun dev" }
+                    ]
+                  }
+                },
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Tests", "command": "bun test --watch" }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Preview", "url": "http://localhost:3000" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+`.cmux/dock.json`:
+
+```json
+{
+  "controls": [
+    { "id": "git", "title": "Git", "command": "lazygit", "cwd": ".", "height": 320 },
+    { "id": "feed", "title": "Feed", "command": "cmux feed tui --opentui", "height": 260 }
+  ]
+}
+```
+
+## SSH Devbox
+
+Use this when the user's normal environment is remote, or when local cmux should
+open a known SSH session beside project notes or a browser preview.
+
+```json
+{
+  "commands": [
+    {
+      "name": "SSH Devbox",
+      "keywords": ["ssh", "remote", "devbox"],
+      "workspace": {
+        "name": "Devbox",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "SSH", "command": "ssh devbox" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Preview", "url": "http://localhost:3000" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Review PR
+
+Use this when a project needs one command to review a pull request with a
+terminal, browser, and notes panel. Adjust the URL and command for the user's
+GitHub workflow.
+
+```json
+{
+  "commands": [
+    {
+      "name": "Review PR",
+      "keywords": ["review", "pull request", "pr"],
+      "workspace": {
+        "name": "PR Review",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "terminal", "name": "GitHub", "command": "gh pr status" }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Pull Request", "url": "https://github.com/owner/repo/pulls" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Docs Workspace
+
+Use this when a repo needs one command for docs authoring with a dev server,
+browser preview, and markdown viewer. Adjust the command, URL, and markdown path
+for the docs stack.
+
+```json
+{
+  "commands": [
+    {
+      "name": "Docs Workspace",
+      "keywords": ["docs", "documentation", "preview"],
+      "workspace": {
+        "name": "Docs",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.45,
+          "children": [
+            {
+              "direction": "vertical",
+              "children": [
+                {
+                  "pane": {
+                    "surfaces": [
+                      { "type": "terminal", "name": "Docs Server", "command": "bun run docs:dev" }
+                    ]
+                  }
+                },
+                {
+                  "pane": {
+                    "surfaces": [
+                      {
+                        "type": "terminal",
+                        "name": "Markdown",
+                        "command": "cmux markdown open docs/README.md --direction right --focus false; exec ${SHELL:-/bin/zsh} -l"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  { "type": "browser", "name": "Docs Preview", "url": "http://localhost:3000/docs" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Quick Agent Buttons
+
+Use this when the user wants tab bar buttons for common agents while keeping
+the default new terminal and browser buttons.
+
+```json
+{
+  "actions": {
+    "codex-new-tab": {
+      "type": "agent",
+      "agent": "codex",
+      "title": "Codex",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    },
+    "claude-new-tab": {
+      "type": "agent",
+      "agent": "claude",
+      "title": "Claude",
+      "target": "newTabInCurrentPane",
+      "palette": true
+    }
+  },
+  "ui": {
+    "surfaceTabBar": {
+      "buttons": [
+        "cmux.newTerminal",
+        "cmux.newBrowser",
+        { "action": "codex-new-tab", "title": "Codex" },
+        { "action": "claude-new-tab", "title": "Claude" }
+      ]
+    }
+  }
+}
+```
+
+## CI Watch
+
+Use this when the user wants a repeatable place for GitHub Actions, CircleCI,
+or release-monitoring commands. Prefer Dock controls for long-running monitors.
+
+`.cmux/dock.json`:
+
+```json
+{
+  "controls": [
+    {
+      "id": "gh-runs",
+      "title": "GitHub Runs",
+      "command": "gh run list --limit 10 && exec ${SHELL:-/bin/zsh} -l",
+      "cwd": ".",
+      "height": 260
+    },
+    {
+      "id": "feed",
+      "title": "Feed",
+      "command": "cmux feed tui --opentui",
+      "height": 260
+    }
+  ]
+}
+```
+
+## Validation Checklist
+
+- Parse any changed JSON or JSONC before reporting success.
+- Keep `cwd` inside the `workspace` object for workspace commands.
+- Confirm `workspaceCommand.commandName` matches a `commands[].name`.
+- Use `ui.newWorkspace.contextMenu` in new examples, not the alias.
+- Keep built-in tab bar buttons only when the user wants them visible.
+- Keep secrets out of config. Use shell profiles, env vars, or a secret store.

--- a/.agents/skills/cmux-debugging/SKILL.md
+++ b/.agents/skills/cmux-debugging/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: cmux-debugging
+description: "Debug logging, Debug menu, runtime pitfalls, typing-latency-sensitive paths, SwiftUI list snapshot boundaries, OS-version repros, and local visual iteration for cmux. Use when adding debug probes, diagnosing UI/runtime issues, touching terminal rendering, tab/sidebar list views, drag/drop UTTypes, or using the Debug menu."
+---
+
+# cmux Debugging
+
+## Debug event log
+
+When adding debug event instrumentation, put events (keys, mouse, focus, splits, tabs) in the unified DEBUG build log. This is not a blanket requirement to add logs to every new code path. Most temporary probes should be added only during the dogfood debug loop and removed before merge.
+
+```bash
+tail -f "$(cat /tmp/cmux-last-debug-log-path 2>/dev/null || echo /tmp/cmux-debug.log)"
+```
+
+- Untagged Debug app: `/tmp/cmux-debug.log`
+- Tagged Debug app (`./scripts/reload.sh --tag <tag>`): `/tmp/cmux-debug-<tag>.log`
+- `reload.sh` writes the current path to `/tmp/cmux-last-debug-log-path`
+- `reload.sh` writes the selected dev CLI path to `/tmp/cmux-last-cli-path`
+- `reload.sh` updates `/tmp/cmux-cli` and `$HOME/.local/bin/cmux-dev` to that CLI
+- Implementation: `Packages/macOS/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift`
+- App shim: `Sources/App/DebugLogging.swift`
+- Free function `cmuxDebugLog("message")` logs with timestamp and appends to file in real time from cmux code
+- The package implementation and app shim are `#if DEBUG`; all call sites must be wrapped in `#if DEBUG` / `#endif`
+- 500-entry ring buffer; `CMUXDebugLog.DebugEventLog.shared.dump()` writes full buffer to file
+- Key events logged in `AppDelegate.swift` (monitor, performKeyEquivalent)
+- Mouse/UI events logged inline in views (ContentView, BrowserPanelView, etc.)
+- Focus events: `focus.panel`, `focus.bonsplit`, `focus.firstResponder`, `focus.moveFocus`
+- Bonsplit events: `tab.select`, `tab.close`, `tab.dragStart`, `tab.drop`, `pane.focus`, `pane.drop`, `divider.dragStart`
+
+## Debug menu
+
+The app has a **Debug** menu in the macOS menu bar only in DEBUG builds. Use it for visual iteration.
+
+- **Debug > Debug Windows** contains panels for tuning layout, colors, and behavior. Entries are alphabetical with no dividers.
+- To add a debug toggle or visual option: create an `NSWindowController` subclass with a `shared` singleton, add it to the "Debug Windows" menu in `Sources/cmuxApp.swift`, and add a SwiftUI view with `@AppStorage` bindings for live changes.
+- When the user says "debug menu" or "debug window", they mean this menu, not `defaults write`.
+
+## Runtime pitfalls
+
+- Custom UTTypes for drag-and-drop must be declared in `Resources/Info.plist` under `UTExportedTypeDeclarations`.
+- Do not add an app-level display link or manual `ghostty_surface_draw` loop; rely on Ghostty wakeups/renderer to avoid typing lag.
+- `WindowTerminalHostView.hitTest()` is typing-latency-sensitive. All divider/sidebar/drag routing is gated to pointer events only. Do not add work outside the `isPointerEvent` guard.
+- `TabItemView` uses `Equatable` conformance plus `.equatable()` to skip body re-evaluation during typing. Do not add environment/store/binding reads without updating equality and the call site.
+- `TerminalSurface.forceRefresh()` is called on every keystroke. Do not add allocations, file I/O, or formatting there.
+- `SurfaceSearchOverlay` must be mounted from `GhosttySurfaceScrollView` in `Sources/GhosttyTerminalView.swift`, not from SwiftUI panel containers.
+- List subtrees with `LazyVStack`, `LazyHStack`, `List`, or `ForEach` must pass immutable row snapshots plus closures below the boundary. Do not pass observable stores into row views.
+- Functions called from SwiftUI `body` must not mutate state or schedule store writes.
+- Foundation, SwiftUI, AttributeGraph, and WebKit semantics can change between macOS major versions. Test on the reporter's macOS before declaring a user repro disproven.
+
+## Detailed references
+
+- Read [references/debug-event-log.md](references/debug-event-log.md) when adding or interpreting debug log probes.
+- Read [references/runtime-pitfalls.md](references/runtime-pitfalls.md) before touching terminal rendering, hit testing, tab rows, list virtualization, search overlay layering, or OS-version-sensitive code.

--- a/.agents/skills/cmux-debugging/agents/openai.yaml
+++ b/.agents/skills/cmux-debugging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Debugging"
+  short_description: "Use cmux debug logs, Debug menu, and runtime pitfall rules safely."
+  default_prompt: "Use this skill when adding debug probes, diagnosing cmux UI/runtime issues, touching typing-sensitive terminal paths, SwiftUI list rows, drag/drop UTTypes, search overlay layering, or Debug menu windows."

--- a/.agents/skills/cmux-debugging/references/debug-event-log.md
+++ b/.agents/skills/cmux-debugging/references/debug-event-log.md
@@ -1,0 +1,66 @@
+# Debug Event Log
+
+The debug event log is the preferred shared destination for temporary and durable DEBUG-only probes.
+
+## Destination
+
+Tagged builds write tag-specific logs:
+
+- untagged Debug app: `/tmp/cmux-debug.log`
+- tagged Debug app: `/tmp/cmux-debug-<tag>.log`
+
+`reload.sh` writes the current path to `/tmp/cmux-last-debug-log-path`, so the most robust tail command is:
+
+```bash
+tail -f "$(cat /tmp/cmux-last-debug-log-path 2>/dev/null || echo /tmp/cmux-debug.log)"
+```
+
+Use this instead of guessing whether the current run is tagged.
+
+## Shape
+
+The package implementation lives in `Packages/macOS/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift`, and the app shim lives in `Sources/App/DebugLogging.swift`.
+
+Call sites use:
+
+```swift
+#if DEBUG
+cmuxDebugLog("focus.panel ...")
+#endif
+```
+
+Every call site must be guarded by `#if DEBUG` / `#endif`. The implementation and shim are DEBUG-only, so unguarded call sites break non-Debug builds.
+
+## When to add probes
+
+Add probes during a dogfood debug loop when they help answer a concrete question:
+
+- Which event path fired?
+- Which panel or pane had focus?
+- Which split/tab/drop transition occurred?
+- Did a stale view or responder receive an event?
+- Did a path fire on every keypress?
+
+Do not add broad instrumentation just because a file is nearby. Remove temporary probes before merge unless they are low-volume and clearly useful for future debugging.
+
+## Naming
+
+Prefer stable event prefixes:
+
+- `focus.panel`
+- `focus.bonsplit`
+- `focus.firstResponder`
+- `focus.moveFocus`
+- `tab.select`
+- `tab.close`
+- `tab.dragStart`
+- `tab.drop`
+- `pane.focus`
+- `pane.drop`
+- `divider.dragStart`
+
+Put dynamic details after the prefix. This makes `rg`, `tail`, and log filtering practical.
+
+## Ring buffer
+
+The debug logger has a 500-entry ring buffer. `CMUXDebugLog.DebugEventLog.shared.dump()` writes the full buffer to file. Use this when the interesting event occurred before you started tailing.

--- a/.agents/skills/cmux-debugging/references/runtime-pitfalls.md
+++ b/.agents/skills/cmux-debugging/references/runtime-pitfalls.md
@@ -1,0 +1,84 @@
+# Runtime Pitfalls
+
+This reference expands the high-risk cmux runtime rules.
+
+## Drag-and-drop UTTypes
+
+Custom UTTypes must be declared in `Resources/Info.plist` under `UTExportedTypeDeclarations`. Examples include:
+
+- `com.splittabbar.tabtransfer`
+- `com.cmux.sidebar-tab-reorder`
+
+If drag/drop works only inside a narrow local test but fails across process or extension boundaries, check Info.plist before rewriting the drag model.
+
+## Terminal rendering and typing latency
+
+Do not add an app-level display link or manual `ghostty_surface_draw` loop. cmux relies on Ghostty wakeups and renderer scheduling. A second draw loop can make typing lag worse and hide the real invalidation source.
+
+`TerminalSurface.forceRefresh()` in `Sources/GhosttyTerminalView.swift` is called on every keystroke. Do not add:
+
+- allocation-heavy formatting
+- file I/O
+- logging to disk
+- string interpolation in hot loops
+- layout work
+
+If you need to observe this path, use the smallest possible DEBUG-only probe and remove it before merge unless it is intentionally durable.
+
+## Hit testing
+
+`WindowTerminalHostView.hitTest()` in `TerminalWindowPortal.swift` is called on every event, including keyboard events. Divider/sidebar/drag routing is intentionally gated to pointer events.
+
+Do not add work outside the `isPointerEvent` guard. Even "small" checks compound on typing paths.
+
+## Tab rows
+
+`TabItemView` in `ContentView.swift` uses `Equatable` conformance plus `.equatable()` to skip body re-evaluation during typing.
+
+Before adding any of these to the view:
+
+- `@EnvironmentObject`
+- `@ObservedObject`
+- `@Binding`
+- a plain store read in `body`
+- a new parameter derived from mutable global state
+
+Update the `==` function and verify the `ForEach` call site still uses `.equatable()`. Prefer passing precomputed immutable values.
+
+## Terminal find layering
+
+`SurfaceSearchOverlay` must be mounted from `GhosttySurfaceScrollView` in `Sources/GhosttyTerminalView.swift`, the AppKit portal layer. Do not mount it from SwiftUI panel containers such as `Sources/Panels/TerminalPanelView.swift`.
+
+Portal-hosted terminal views can sit above SwiftUI during split/workspace churn. Mounting the search UI at the wrong layer creates intermittently hidden or detached search controls.
+
+## Snapshot boundary for list subtrees
+
+In any SwiftUI panel whose `body` contains a `LazyVStack`, `LazyHStack`, `List`, or `ForEach` of rows, no view below that boundary may hold a reference to an `ObservableObject` or `@Observable` store. That includes:
+
+- `@ObservedObject`
+- `@EnvironmentObject`
+- `@StateObject`
+- `@Bindable`
+- a plain `let store: SomeStore`
+
+Rows and drop gaps receive immutable value snapshots plus closure action bundles only.
+
+This avoids the class of bugs where an orthogonal published change invalidates every row and thrashes `LazyLayoutViewCache`, causing a main-thread spin loop. Reference patterns include `IndexSectionActions`, `SectionGapActions`, and `SessionSearchFn` in `Sources/SessionIndexView.swift`.
+
+## No body-time mutation
+
+A function called from SwiftUI `body`, directly or through a helper, must not:
+
+- write observable state
+- schedule `Task { @MainActor in store.x = ... }`
+- call `DispatchQueue.main.async` to write store state
+
+State-changing work triggered by "new data appeared" belongs in a reload completion, a `didSet`, or a property observer. It does not belong in the projection that feeds `ForEach`.
+
+## OS-version repros
+
+Foundation, SwiftUI, AttributeGraph, and WebKit behavior can change silently between macOS versions. A function that seems deterministic on macOS 26 may behave differently on macOS 14 or 15.
+
+Concrete example: `URL(fileURLWithPath: "/").deletingLastPathComponent().path` returned `"/.."` on macOS 14 and 15 but `"/"` on macOS 26.
+
+When a user reports a repro on an older macOS, test on that macOS before declaring the repro disproven. AWS M4 Pro builders such as `cmux-aws-mac`, `cmux-aws-m4pro`, and `aws-m4pro-1..6` are pre-provisioned on macOS 15.7.4 and are the preferred empirical repro path.

--- a/.agents/skills/cmux-dev-workflow/SKILL.md
+++ b/.agents/skills/cmux-dev-workflow/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cmux-dev-workflow
+description: "Contributor workflow rules for cmux setup, Xcode project normalization, tagged sidebar ExtensionKit development, and dev builds. Use when setting up the cmux repo, changing Xcode project files, adding sidebar extensions, or working with tagged debug builds."
+---
+
+# cmux Dev Workflow
+
+## Tagged local dev
+
+After making code changes, always run the reload script with a tag to build the Debug app:
+
+```bash
+./scripts/reload.sh --tag <short-tag>
+```
+
+By default, `reload.sh` builds but does not launch the app. Pass `--launch` only when you need to open it automatically.
+
+Never run bare `xcodebuild` or open an untagged `cmux DEV.app`. Untagged builds share the default debug socket and bundle ID with other agents, causing conflicts and stealing focus.
+
+For CLI or socket dogfood against a tagged Debug app, use the tag-bound helper and set `CMUX_TAG`:
+
+```bash
+CMUX_TAG=<tag> scripts/cmux-debug-cli.sh list-workspaces
+```
+
+Do not use `/tmp/cmux-cli` for tagged dogfood. That symlink points at the most recently reloaded build.
+
+When rebuilding cmuxd for release/bundling, always use ReleaseFast:
+
+```bash
+cd cmuxd && zig build -Doptimize=ReleaseFast
+```
+
+## Initial setup
+
+Run the setup script to initialize submodules, build GhosttyKit, and install the pbxproj normalization pre-commit hook:
+
+```bash
+./scripts/setup.sh
+```
+
+## Xcode toolchain
+
+The team is pinned to Xcode 26.x. `.xcode-version` records the major; `cmux.xcodeproj/project.pbxproj` carries `objectVersion = 60`, which is what Xcode 26 writes by default. (objectVersion 77 is reserved for projects that adopt synchronized folder groups, which cmux does not use yet. Bumping to a different value requires a deliberate team decision.)
+
+`scripts/setup.sh` installs a tracked pre-commit hook (`scripts/git-hooks/pre-commit`) that runs `scripts/normalize-pbxproj.py` on any staged `cmux.xcodeproj/project.pbxproj`, sorting the high-churn sections so Xcode's nondeterministic reordering never reaches a commit. The hook is idempotent. CI runs `scripts/check-pbxproj.sh` to enforce both the `objectVersion` pin and normalization, so anyone who skips the hook (or never ran setup) gets a clear failure on their PR.
+
+`.xcode-version` is the single source of truth. To bump the pin: edit `.xcode-version`, open `cmux.xcodeproj` in the new Xcode (which rewrites `objectVersion` automatically when it touches the file), and add a case for the new Xcode major in `scripts/check-pbxproj.sh` mapping it to the `objectVersion` that major writes.
+
+## Sidebar extension point (dev tagging)
+
+Each tagged dev build gets its own ExtensionKit sidebar extension point so concurrent dev builds don't collide. Three build settings drive this:
+
+- `CMUX_SIDEBAR_EXTENSION_POINT_ID` (default `com.cmuxterm.app.cmux.sidebar`): the extension point identifier baked into Info.plist at build time.
+- `CMUX_BUNDLE_ID_SUFFIX` (default empty): inserted into the app and appex bundle ids so a tagged extension gets a distinct identity that pkd records separately.
+- `CMUX_DISPLAY_NAME_SUFFIX` (default empty): appended to the appex `CFBundleDisplayName`. The OS groups sidebar extensions by display name for the enable/disable + availability counts the host reads (`AppExtensionIdentity` exposes only `bundleIdentifier`, `localizedName`, `extensionPointIdentifier`, `id` — cmux already keys its own identity off the stable `bundleIdentifier`, but the OS-level grouping is by name). Two same-named appexes installed side by side (a base build and a tagged build) are treated as one logical extension, so toggling one perturbs the other; a per-tag display name keeps them distinct.
+
+The host resolves its point id at runtime from the Info.plist key `CMUXSidebarExtensionPointIdentifier` via `CmuxSidebarExtensionPoint.identifier(in:)`. `./scripts/reload.sh --tag <tag>` scopes the host point to `com.cmuxterm.app.debug.<tag>.cmux.sidebar`. `./scripts/reload-extension.sh --tag <tag> [--host-bundle-id <id>] [--example sample|tabs|both]` builds a matching tag-scoped sample extension, passing `CMUX_SIDEBAR_EXTENSION_POINT_ID=<host-bundle-id>.cmux.sidebar`, `CMUX_BUNDLE_ID_SUFFIX=.<tag>`, and `CMUX_DISPLAY_NAME_SUFFIX=" <tag>"`. It installs exactly what xcodebuild produced (xcodebuild ad-hoc signs with entitlements intact) — it does NOT re-sign, because a bare `codesign --force --sign -` strips the appex entitlements and the extension then drops its host XPC connection. pkd ingests the tagged copy because its bundle id is distinct. Verify with `pluginkit -m -p <host-bundle-id>.cmux.sidebar`.
+
+To author a NEW sample extension that is tag-ready:
+
+- appex Info.plist: `EXAppExtensionAttributes:EXExtensionPointIdentifier = $(CMUX_SIDEBAR_EXTENSION_POINT_ID)`.
+- add `CMUX_SIDEBAR_EXTENSION_POINT_ID` (default `com.cmuxterm.app.cmux.sidebar`), `CMUX_BUNDLE_ID_SUFFIX` (default empty), and `CMUX_DISPLAY_NAME_SUFFIX` (default empty) build settings to the app and appex targets in all build configs.
+- `PRODUCT_BUNDLE_IDENTIFIER` = `<appBase>$(CMUX_BUNDLE_ID_SUFFIX)` for the app target and `<appBase>$(CMUX_BUNDLE_ID_SUFFIX).<leaf>` for the appex (suffix before the appex leaf so the appex id stays prefixed by the app id).
+- appex `INFOPLIST_KEY_CFBundleDisplayName` (or the `CFBundleDisplayName` Info.plist value) = `<Name>$(CMUX_DISPLAY_NAME_SUFFIX)`.
+- it must be ad-hoc signed by xcodebuild (Info.plist bound, entitlements intact) for pkd to ingest the tagged copy; do not re-sign post-build.
+
+## Detailed references
+
+- Read [references/tagged-builds.md](references/tagged-builds.md) for detailed tagged reload, app link, socket, and cleanup behavior.
+- Read [references/xcode-project-normalization.md](references/xcode-project-normalization.md) before touching `.xcode-version` or `cmux.xcodeproj/project.pbxproj`.
+- Read [references/sidebar-extension-tagging.md](references/sidebar-extension-tagging.md) when changing ExtensionKit sidebar extension identifiers, tagged sample extensions, or `pluginkit` verification.

--- a/.agents/skills/cmux-dev-workflow/agents/openai.yaml
+++ b/.agents/skills/cmux-dev-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Dev Workflow"
+  short_description: "Follow cmux setup, Xcode, and tagged ExtensionKit development rules."
+  default_prompt: "Use this skill when setting up cmux, touching Xcode project files, working with tagged debug builds, or adding sidebar extensions that must coexist with other dev builds."

--- a/.agents/skills/cmux-dev-workflow/references/sidebar-extension-tagging.md
+++ b/.agents/skills/cmux-dev-workflow/references/sidebar-extension-tagging.md
@@ -1,0 +1,60 @@
+# Sidebar Extension Tagging
+
+Tagged dev builds need distinct ExtensionKit sidebar extension points so concurrent dev builds do not collide.
+
+## Build settings
+
+Three build settings drive the tagging model:
+
+- `CMUX_SIDEBAR_EXTENSION_POINT_ID`
+- `CMUX_BUNDLE_ID_SUFFIX`
+- `CMUX_DISPLAY_NAME_SUFFIX`
+
+The default extension point is:
+
+```text
+com.cmuxterm.app.cmux.sidebar
+```
+
+Tagged host builds scope it to:
+
+```text
+com.cmuxterm.app.debug.<tag>.cmux.sidebar
+```
+
+## Why display name matters
+
+`AppExtensionIdentity` exposes stable fields such as bundle identifier, localized name, extension point identifier, and id. cmux keys its identity off the stable bundle identifier, but OS-level enable/disable and availability grouping uses display name.
+
+Two same-named appexes installed side by side can be treated as one logical extension. Per-tag display names keep tagged sample extensions distinct.
+
+## Tagged sample extensions
+
+`./scripts/reload-extension.sh --tag <tag> [--host-bundle-id <id>] [--example sample|tabs|both]` builds a matching tag-scoped sample extension.
+
+It passes:
+
+- `CMUX_SIDEBAR_EXTENSION_POINT_ID=<host-bundle-id>.cmux.sidebar`
+- `CMUX_BUNDLE_ID_SUFFIX=.<tag>`
+- `CMUX_DISPLAY_NAME_SUFFIX=" <tag>"`
+
+It installs exactly what xcodebuild produced. It does not re-sign. A bare `codesign --force --sign -` strips appex entitlements and the extension drops its host XPC connection.
+
+## New sample extension checklist
+
+For a new tag-ready sample extension:
+
+- appex Info.plist has `EXAppExtensionAttributes:EXExtensionPointIdentifier = $(CMUX_SIDEBAR_EXTENSION_POINT_ID)`
+- app and appex targets define `CMUX_SIDEBAR_EXTENSION_POINT_ID`
+- app and appex targets define `CMUX_BUNDLE_ID_SUFFIX`
+- app and appex targets define `CMUX_DISPLAY_NAME_SUFFIX`
+- app `PRODUCT_BUNDLE_IDENTIFIER` uses `<appBase>$(CMUX_BUNDLE_ID_SUFFIX)`
+- appex `PRODUCT_BUNDLE_IDENTIFIER` uses `<appBase>$(CMUX_BUNDLE_ID_SUFFIX).<leaf>`
+- appex display name appends `$(CMUX_DISPLAY_NAME_SUFFIX)`
+- xcodebuild ad-hoc signs the appex with entitlements intact
+
+Verify with:
+
+```bash
+pluginkit -m -p <host-bundle-id>.cmux.sidebar
+```

--- a/.agents/skills/cmux-dev-workflow/references/tagged-builds.md
+++ b/.agents/skills/cmux-dev-workflow/references/tagged-builds.md
@@ -1,0 +1,61 @@
+# Tagged Builds
+
+Tagged builds isolate app name, bundle ID, socket, and DerivedData path so multiple agents and the user's normal app do not collide.
+
+## Reload
+
+Use:
+
+```bash
+./scripts/reload.sh --tag <tag>
+```
+
+`reload.sh` builds but does not launch by default. It terminates any running app with the same tag after a successful build, so opening the printed app path launches the fresh binary.
+
+Use:
+
+```bash
+./scripts/reload.sh --tag <tag> --launch
+```
+
+only when the task requires launching.
+
+## App path links
+
+`reload.sh` prints:
+
+```text
+App path:
+  /absolute/path/to/cmux DEV <tag>.app
+```
+
+Build chat links from that exact path. Prepend `file://` and URL-encode spaces as `%20`. Do not hardcode DerivedData paths and never use `/tmp/cmux-<tag>/...` app links in chat output.
+
+## Tagged CLI and socket
+
+For CLI or socket dogfood against a tagged Debug app, use:
+
+```bash
+CMUX_TAG=<tag> scripts/cmux-debug-cli.sh list-workspaces
+CMUX_TAG=<tag> scripts/cmux-debug-cli.sh send --workspace workspace:1 --surface surface:1 "echo ok"
+```
+
+Do not use `/tmp/cmux-cli` for tagged dogfood. That symlink points at the most recently reloaded build and can target the user's main app socket.
+
+The helper:
+
+- refuses to run without `CMUX_TAG`
+- targets `/tmp/cmux-debug-<tag>.sock`
+- uses the matching tagged CLI from DerivedData
+- scrubs ambient cmux terminal context
+- sets `CMUX_SOCKET_PATH`, `CMUX_BUNDLE_ID`, and `CMUX_BUNDLED_CLI_PATH`
+
+## Cleanup
+
+Before launching a new tagged run, clean up older tags started in the same session:
+
+- quit old tagged app
+- remove its `/tmp` socket if stale
+- remove derived data only when you are sure no active task needs it
+
+Do not open an untagged `cmux DEV.app` from DerivedData. It shares the default debug socket and bundle ID with other agents.

--- a/.agents/skills/cmux-dev-workflow/references/xcode-project-normalization.md
+++ b/.agents/skills/cmux-dev-workflow/references/xcode-project-normalization.md
@@ -1,0 +1,46 @@
+# Xcode Project Normalization
+
+cmux is pinned to Xcode 26.x. `.xcode-version` records the major version. `cmux.xcodeproj/project.pbxproj` carries `objectVersion = 60`, which is what Xcode 26 writes by default.
+
+`objectVersion = 77` is reserved for projects that adopt synchronized folder groups. cmux does not use synchronized folder groups yet.
+
+## Pre-commit hook
+
+`scripts/setup.sh` installs:
+
+```text
+scripts/git-hooks/pre-commit
+```
+
+The hook runs:
+
+```bash
+scripts/normalize-pbxproj.py
+```
+
+on staged `cmux.xcodeproj/project.pbxproj` changes. This sorts high-churn sections so Xcode's nondeterministic reordering does not reach commits.
+
+## CI guard
+
+CI runs:
+
+```bash
+scripts/check-pbxproj.sh
+```
+
+It enforces both:
+
+- the `.xcode-version` / `objectVersion` pin
+- pbxproj normalization
+
+## Bumping Xcode
+
+To bump the pin:
+
+1. Edit `.xcode-version`.
+2. Open `cmux.xcodeproj` in the new Xcode so it rewrites `objectVersion`.
+3. Add a case in `scripts/check-pbxproj.sh` mapping the new Xcode major to the objectVersion that Xcode writes.
+4. Normalize the project file.
+5. Treat the bump as a deliberate team decision.
+
+Do not change `objectVersion` opportunistically as part of unrelated project edits.

--- a/.agents/skills/cmux-diagnostics/SKILL.md
+++ b/.agents/skills/cmux-diagnostics/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cmux-diagnostics
+description: "Run end-user cmux diagnostics. Use when cmux hooks, notifications, session restore, settings, browser automation, socket access, CLI control, or agent resume behavior is not working, or when the user asks for a cmux health check, doctor report, or support-safe debug summary."
+---
+
+# cmux Diagnostics
+
+Use this skill to collect and interpret support-safe cmux diagnostics for end users. Default to read-only checks. Do not dump hook config files, session stores, prompt logs, tokens, or environment secrets.
+
+## Quick Report
+
+Run the bundled read-only diagnostic script first:
+
+```bash
+# From a cmux checkout
+skills/cmux-diagnostics/scripts/cmux-diagnostics
+
+# From an installed skill
+~/.agents/skills/cmux-diagnostics/scripts/cmux-diagnostics
+
+# From a Codex-only skills.sh install
+~/.codex/skills/cmux-diagnostics/scripts/cmux-diagnostics
+```
+
+Use `--include-context` only when workspace names, cwd paths, and current cmux identifiers are relevant to the user-reported issue:
+
+```bash
+skills/cmux-diagnostics/scripts/cmux-diagnostics --include-context
+```
+
+## What to Check
+
+1. CLI and socket health:
+
+   ```bash
+   command -v cmux
+   cmux ping
+   cmux capabilities --json
+   ```
+
+   If socket commands fail, check whether the agent is running inside a cmux terminal and whether socket automation is enabled.
+
+2. Settings health:
+
+   ```bash
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings validate
+   ~/.agents/skills/cmux-settings/scripts/cmux-settings get terminal.autoResumeAgentSessions
+   ```
+
+   If the user installed with `skills.sh`, use `~/.codex/skills/cmux-settings/scripts/cmux-settings` instead.
+   If `terminal.autoResumeAgentSessions` is false, cmux restores panes but will not automatically resume saved agent sessions.
+
+3. Hook installation:
+
+   ```bash
+   cmux hooks setup --agent codex
+   cmux hooks setup --agent opencode
+   cmux hooks setup
+   ```
+
+   Only run install or uninstall commands after the user agrees. `cmux hooks setup` installs supported agents found on PATH and skips missing agents.
+
+4. Session restore evidence:
+
+   ```bash
+   ls -lh ~/.cmuxterm/*-hook-sessions.json 2>/dev/null
+   ```
+
+   Missing session stores usually means the agent has not run inside cmux since hooks were installed, hooks are disabled, or the agent integration does not support resume capture.
+
+5. Notification path:
+
+   ```bash
+   cmux notify "cmux diagnostic test"
+   ```
+
+   Use this only when the user is ready for a visible test notification.
+
+## Interpretation
+
+- `cmux` not found: the CLI is not installed or not on PATH for this shell.
+- `cmux ping` fails: app is not reachable through the current socket path, the app is closed, or automation access is disabled.
+- No `CMUX_WORKSPACE_ID` or `CMUX_SURFACE_ID`: the command is probably running outside a cmux terminal. Some hooks intentionally no-op outside cmux.
+- Hook config exists but no session store: run one supported agent inside cmux after installing hooks, then re-check.
+- Session store exists but restore does not launch agents: check `terminal.autoResumeAgentSessions` and whether the saved executable still exists on PATH.
+- Settings validation fails: fix the config first. Invalid config can make later symptoms misleading.
+
+## Rules
+
+- Stay read-only until the user asks to fix something.
+- Never print raw hook files, session JSON, prompt logs, shell history, tokens, or API keys.
+- Summarize file presence, size, modified time, and marker presence instead of contents.
+- Prefer narrow fixes such as `cmux hooks setup --agent codex` over reinstalling every integration.
+- After a fix, rerun the diagnostic script and report the changed lines.

--- a/.agents/skills/cmux-diagnostics/agents/openai.yaml
+++ b/.agents/skills/cmux-diagnostics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Diagnostics"
+  short_description: "Check cmux hooks, restore, CLI, and settings."
+  default_prompt: "Use $cmux-diagnostics to collect a read-only cmux health report and explain any hook or session restore problems."

--- a/.agents/skills/cmux-diagnostics/scripts/cmux-diagnostics
+++ b/.agents/skills/cmux-diagnostics/scripts/cmux-diagnostics
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+include_context=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --include-context)
+      include_context=1
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: cmux-diagnostics [--include-context]
+
+Print a read-only, support-safe cmux diagnostics report. By default this avoids
+workspace names, cwd paths, hook contents, session JSON, and secrets.
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'cmux-diagnostics: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+safe_path() {
+  local path="$1"
+  if [[ "$path" == "$HOME" ]]; then
+    printf '~'
+  elif [[ "$path" == "$HOME"/* ]]; then
+    printf '~/%s' "${path#"$HOME"/}"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+run_status() {
+  local label="$1"
+  shift
+  printf '%s: ' "$label"
+  if "$@" >/dev/null 2>&1; then
+    printf 'ok\n'
+  else
+    printf 'failed\n'
+  fi
+}
+
+file_summary() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    local bytes modified
+    bytes="$(wc -c <"$path" 2>/dev/null | tr -d ' ' || true)"
+    modified="$(stat -f '%Sm' -t '%Y-%m-%d %H:%M:%S %z' "$path" 2>/dev/null || stat -c '%y' "$path" 2>/dev/null || printf 'unknown')"
+    printf 'present bytes=%s modified=%s\n' "${bytes:-unknown}" "$modified"
+  elif [[ -e "$path" ]]; then
+    printf 'non-regular\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+marker_summary() {
+  local path="$1"
+  local marker="$2"
+  if [[ -f "$path" ]]; then
+    if grep -Fq "$marker" "$path" 2>/dev/null; then
+      printf 'marker-present\n'
+    else
+      printf 'marker-missing\n'
+    fi
+  elif [[ -e "$path" ]]; then
+    printf 'non-regular\n'
+  else
+    printf 'missing\n'
+  fi
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+skill_dir="$(cd -- "$script_dir/.." >/dev/null 2>&1 && pwd)"
+skills_root="$(cd -- "$skill_dir/.." >/dev/null 2>&1 && pwd)"
+settings_helper="$skills_root/cmux-settings/scripts/cmux-settings"
+if [[ ! -x "$settings_helper" && -x "$HOME/.agents/skills/cmux-settings/scripts/cmux-settings" ]]; then
+  settings_helper="$HOME/.agents/skills/cmux-settings/scripts/cmux-settings"
+elif [[ ! -x "$settings_helper" && -x "$HOME/.codex/skills/cmux-settings/scripts/cmux-settings" ]]; then
+  settings_helper="$HOME/.codex/skills/cmux-settings/scripts/cmux-settings"
+fi
+
+section "cmux diagnostics"
+printf 'date: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+printf 'shell: %s\n' "${SHELL:-unknown}"
+printf 'inside_cmux: '
+if [[ -n "${CMUX_WORKSPACE_ID:-}" || -n "${CMUX_SURFACE_ID:-}" ]]; then
+  printf 'yes\n'
+else
+  printf 'no\n'
+fi
+printf 'cmux_workspace_id_set: %s\n' "$([[ -n "${CMUX_WORKSPACE_ID:-}" ]] && printf yes || printf no)"
+printf 'cmux_surface_id_set: %s\n' "$([[ -n "${CMUX_SURFACE_ID:-}" ]] && printf yes || printf no)"
+if [[ "${CMUX_SOCKET_PATH+x}" == "x" ]]; then
+  printf 'cmux_socket_path: %s (from CMUX_SOCKET_PATH)\n' "$(safe_path "$CMUX_SOCKET_PATH")"
+elif [[ "${CMUX_SOCKET+x}" == "x" ]]; then
+  printf 'cmux_socket_path: %s (from CMUX_SOCKET)\n' "$(safe_path "$CMUX_SOCKET")"
+else
+  printf 'cmux_socket_path: unset\n'
+fi
+printf 'cmux_socket_password_set: %s\n' "$([[ -n "${CMUX_SOCKET_PASSWORD:-}" ]] && printf yes || printf no)"
+
+section "cli"
+if command -v cmux >/dev/null 2>&1; then
+  printf 'cmux_path: %s\n' "$(safe_path "$(command -v cmux)")"
+  if cmux --version >/dev/null 2>&1; then
+    printf 'cmux_version: %s\n' "$(cmux --version 2>/dev/null | head -n 1)"
+  else
+    printf 'cmux_version: unavailable\n'
+  fi
+  run_status "cmux_ping" cmux ping
+  run_status "cmux_capabilities" cmux capabilities --json
+  if [[ "$include_context" -eq 1 ]]; then
+    printf 'identify_json:\n'
+    cmux identify --json 2>/dev/null || printf '  unavailable\n'
+  fi
+else
+  printf 'cmux_path: missing\n'
+fi
+
+section "settings"
+printf 'cmux_json: '
+file_summary "$HOME/.config/cmux/cmux.json"
+printf 'legacy_settings_json: '
+file_summary "$HOME/.config/cmux/settings.json"
+if [[ -x "$settings_helper" ]]; then
+  run_status "cmux_settings_validate" "$settings_helper" validate
+  printf 'auto_resume_agent_sessions: '
+  "$settings_helper" get terminal.autoResumeAgentSessions 2>/dev/null || printf 'default-or-unset\n'
+else
+  printf 'cmux_settings_helper: missing (%s)\n' "$(safe_path "$settings_helper")"
+fi
+
+section "hook configs"
+declare -a hook_checks=(
+  "codex:$HOME/.codex/hooks.json:cmux hooks codex"
+  "codex-config:$HOME/.codex/config.toml:codex_hooks"
+  "opencode-session:$HOME/.config/opencode/plugins/cmux-session.js:cmux hooks opencode"
+  "opencode-feed:$HOME/.config/opencode/plugins/cmux-feed.js:cmux hooks feed --source opencode"
+  "pi:$HOME/.pi/agent/extensions/cmux-session.ts:cmux hooks pi"
+  "amp:$HOME/.config/amp/plugins/cmux-session.ts:cmux hooks amp"
+  "cursor:$HOME/.cursor/hooks.json:cmux hooks cursor"
+  "gemini:$HOME/.gemini/settings.json:cmux hooks gemini"
+  "rovodev:$HOME/.rovodev/rovodev.yml:cmux hooks rovodev"
+  "hermes-agent:$HOME/.hermes/config.yaml:cmux hooks hermes-agent"
+  "copilot:$HOME/.copilot/settings.json:cmux hooks copilot"
+  "codebuddy:$HOME/.codebuddy/settings.json:cmux hooks codebuddy"
+  "factory:$HOME/.factory/settings.json:cmux hooks factory"
+  "qoder:$HOME/.qoder/settings.json:cmux hooks qoder"
+)
+for entry in "${hook_checks[@]}"; do
+  IFS=: read -r name path marker <<<"$entry"
+  printf '%s: %s ' "$name" "$(safe_path "$path")"
+  marker_summary "$path" "$marker"
+done
+
+section "session stores"
+shopt -s nullglob
+stores=("$HOME"/.cmuxterm/*-hook-sessions.json)
+if [[ "${#stores[@]}" -eq 0 ]]; then
+  printf 'session_store_files: none\n'
+else
+  printf 'session_store_files: %s\n' "${#stores[@]}"
+  for path in "${stores[@]}"; do
+    printf '%s: ' "$(basename "$path")"
+    file_summary "$path"
+  done
+fi
+
+section "agent binaries"
+for bin in claude codex opencode pi amp cursor-agent gemini rovo rovodev hermes-agent gh copilot codebuddy droid qodercli; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    printf '%s: present (%s)\n' "$bin" "$(safe_path "$(command -v "$bin")")"
+  else
+    printf '%s: missing\n' "$bin"
+  fi
+done

--- a/.agents/skills/cmux-ghostty/SKILL.md
+++ b/.agents/skills/cmux-ghostty/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: cmux-ghostty
+description: "Ghostty submodule and GhosttyKit workflow rules for cmux. Use when modifying the ghostty submodule, rebuilding GhosttyKit.xcframework, updating the parent submodule pointer, or documenting fork conflict notes."
+---
+
+# cmux Ghostty
+
+## GhosttyKit builds
+
+When rebuilding GhosttyKit.xcframework, always use Release optimizations:
+
+```bash
+cd ghostty && zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+```
+
+## Submodule workflow
+
+Ghostty changes must be committed in the `ghostty` submodule and pushed to the `manaflow-ai/ghostty` fork. Keep `docs/ghostty-fork.md` up to date with any fork changes and conflict notes.
+
+```bash
+cd ghostty
+git remote -v  # origin = upstream, manaflow = fork
+git checkout -b <branch>
+git add <files>
+git commit -m "..."
+git push manaflow <branch>
+```
+
+To keep the fork up to date with upstream:
+
+```bash
+cd ghostty
+git fetch origin
+git checkout main
+git merge origin/main
+git push manaflow main
+```
+
+Then update the parent repo with the new submodule SHA:
+
+```bash
+cd ..
+git add ghostty
+git commit -m "Update ghostty submodule"
+```
+
+## Submodule safety
+
+When modifying a submodule, always push the submodule commit to its remote `main` branch before committing the updated pointer in the parent repo. Never commit on a detached HEAD or temporary branch; the commit can be orphaned and lost.
+
+Verify with:
+
+```bash
+cd <submodule> && git merge-base --is-ancestor HEAD origin/main
+```
+
+## Detailed reference
+
+- Read [references/submodule-safety.md](references/submodule-safety.md) before committing submodule pointer updates or resolving Ghostty fork conflicts.

--- a/.agents/skills/cmux-ghostty/agents/openai.yaml
+++ b/.agents/skills/cmux-ghostty/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Ghostty"
+  short_description: "Handle Ghostty submodule, fork, and GhosttyKit build workflow safely."
+  default_prompt: "Use this skill when modifying the ghostty submodule, rebuilding GhosttyKit.xcframework, pushing Ghostty fork changes, updating the parent submodule pointer, or editing docs/ghostty-fork.md."

--- a/.agents/skills/cmux-ghostty/references/submodule-safety.md
+++ b/.agents/skills/cmux-ghostty/references/submodule-safety.md
@@ -1,0 +1,51 @@
+# Submodule Safety
+
+Submodule commits can be easy to lose. The parent repository records only a commit SHA, not the branch that made the SHA reachable.
+
+## Safe sequence
+
+1. Enter the submodule.
+2. Create or select the intended branch.
+3. Commit the submodule changes.
+4. Push the submodule commit to the correct remote.
+5. Verify the pushed branch contains the commit.
+6. Return to the parent repository.
+7. Commit the updated submodule pointer.
+
+For Ghostty:
+
+```bash
+cd ghostty
+git remote -v
+git checkout -b <branch>
+git add <files>
+git commit -m "..."
+git push manaflow <branch>
+```
+
+If the parent pointer is supposed to track fork `main`, make sure the commit is an ancestor of that remote branch:
+
+```bash
+git fetch manaflow main
+git merge-base --is-ancestor HEAD manaflow/main
+```
+
+The top-level CLAUDE note uses `origin/main` as the generic verification form for submodules. In the Ghostty submodule, check the actual remote names first because `origin` may be upstream and `manaflow` may be the fork.
+
+## Detached HEAD hazard
+
+Do not commit submodule changes on a detached HEAD and then update the parent pointer. That creates a parent commit pointing at a SHA that may not be reachable from any remote branch. A future checkout or CI job can fail to fetch it.
+
+## Fork documentation
+
+Keep `docs/ghostty-fork.md` updated when fork changes or conflict notes matter for future upstream merges. The point is to preserve why the fork diverged, not just that it diverged.
+
+## GhosttyKit optimization
+
+Rebuild GhosttyKit.xcframework with ReleaseFast:
+
+```bash
+cd ghostty && zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+```
+
+Debug or default optimization builds can hide performance characteristics and should not be used for the checked-in framework refresh path.

--- a/.agents/skills/cmux-keyboard-shortcuts/SKILL.md
+++ b/.agents/skills/cmux-keyboard-shortcuts/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: cmux-keyboard-shortcuts
+description: "Guide and apply cmux keyboard shortcut customization. Use when the user asks to customize, rebind, unbind, reset, audit, or create shortcut templates for cmux, including tmux-style, Vim-style, terminal-first, browser-heavy, iTerm/Terminal-like, or agent-triage layouts."
+---
+
+# cmux-keyboard-shortcuts
+
+Use this skill to turn a user's workflow preferences into cmux shortcut bindings in `~/.config/cmux/cmux.json`. It should guide the user, propose compact templates, apply selected changes, and confirm the config parses with recognized keys.
+
+## Prerequisites
+
+- Work from a cmux checkout or worktree root when possible.
+- Use `skills/cmux-settings/scripts/cmux-settings` for every read/write. It reads JSONC, writes atomically, and validates JSON plus recognized settings keys.
+- For action IDs, read `skills/cmux-settings/references/shortcut-actions.md`.
+- For current defaults, read `web/data/cmux-shortcuts.ts` or `Sources/KeyboardShortcutSettings.swift`.
+
+```bash
+find_cmux_settings() {
+  local root
+  root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || pwd)"
+  for candidate in \
+    "$root/skills/cmux-settings/scripts/cmux-settings" \
+    "${CODEX_HOME:-$HOME/.codex}/skills/cmux-settings/scripts/cmux-settings" \
+    "$HOME/.agents/skills/cmux-settings/scripts/cmux-settings"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ -z "${CMUX_SETTINGS:-}" ]]; then
+  CMUX_SETTINGS="$(find_cmux_settings)" || {
+    echo "cmux-settings helper not found; run from a cmux checkout or install cmux-settings" >&2
+    exit 1
+  }
+fi
+```
+
+## Shortcut Model
+
+- Setting path: `shortcuts.bindings.<actionId>`.
+- Single stroke: `"cmd+b"`.
+- Chord: `["ctrl+b","c"]`. The first stroke needs a modifier unless the key is Space. The second stroke can be bare.
+- Unbind: prefer `null` for explicit unbinds. `""`, `"none"`, `"clear"`, `"unbound"`, and `"disabled"` are accepted aliases, but `null` is the clearest JSON value and matches the templates below.
+- `selectSurfaceByNumber` and `selectWorkspaceByNumber` must use a digit from 1 to 9. `cmd+1` means the full `cmd+1` through `cmd+9` family.
+- `showHideAllWindows` and `globalSearch` are system-wide shortcuts. They cannot be chords, require modifiers, and may be rejected by macOS if reserved.
+- `showHideAllWindows` also requires Settings > Global Hotkey > Enable System-Wide Hotkey. The binding can validate in `cmux.json` while the feature is disabled, so warn the user to enable that setting before reporting the shortcut as usable.
+- `unset` deletes a `cmux.json` override. It does not clear shortcut changes saved through the Settings UI/UserDefaults. If the user asks for true built-in defaults, tell them to use Settings > Keyboard Shortcuts > Reset Default Shortcuts after clearing file-managed overrides, then verify in the app. For `showHideAllWindows`, use Settings > Global Hotkey to restore the shortcut to `ctrl+opt+cmd+.` because Keyboard Shortcuts > Reset Default Shortcuts intentionally skips the global hotkey.
+- Saving `cmux.json` live reloads. Do not tell the user to restart cmux.
+
+## Workflow
+
+1. Classify the request:
+   - One-off rebind or unbind: map the phrase to an action ID, apply it, validate, and report the previous and new binding.
+   - Audit-only request: inspect current bindings, validate, and summarize overrides/unbound shortcuts without writing.
+   - Reset request: clarify whether the user means file-managed overrides or true built-in defaults. For file-managed resets, use `unset` for named actions. For true built-in defaults, remove file overrides and direct the user to Settings > Keyboard Shortcuts > Reset Default Shortcuts; do not report built-in defaults restored from `cmux-settings` alone. If `showHideAllWindows` is included, also direct them to Settings > Global Hotkey to restore `ctrl+opt+cmd+.` and the enable toggle.
+   - Broad customization request: propose 3 to 5 templates from "Preset Templates" and ask the user to choose.
+   - Named style such as tmux, Vim, iTerm, browser, or agent triage: select the closest template, show the changed actions and likely collisions, and ask before a bulk apply unless the user explicitly said to apply it.
+2. Inspect existing config:
+
+   ```bash
+   "$CMUX_SETTINGS" path
+   "$CMUX_SETTINGS" get shortcuts.bindings 2>/dev/null || printf '{}\n'
+   "$CMUX_SETTINGS" validate
+   ```
+
+3. Before applying a template, snapshot prior values for every action you will change. A path that is absent must revert with `unset`; a path with an existing custom value must revert with `set <same-json-value>`.
+
+   ```bash
+   "$CMUX_SETTINGS" get shortcuts.bindings.focusLeft 2>/dev/null || printf '<absent>\n'
+   ```
+
+4. Apply only the chosen action paths:
+
+   ```bash
+   "$CMUX_SETTINGS" set shortcuts.bindings.newSurface '["ctrl+b","c"]'
+   "$CMUX_SETTINGS" set shortcuts.bindings.focusLeft cmd+opt+h
+   "$CMUX_SETTINGS" set shortcuts.bindings.sendFeedback null
+   "$CMUX_SETTINGS" validate
+   ```
+
+5. Verify readback for changed actions:
+
+   ```bash
+   "$CMUX_SETTINGS" get shortcuts.bindings.newSurface
+   ```
+
+6. Finish with the template name, changed actions, and exact revert commands from the snapshot. Use `unset` only for actions that were absent before the template; use `set` to restore previous custom bindings.
+
+## Preset Templates
+
+Use these as proposal templates. Apply them action by action, not by overwriting the whole `shortcuts.bindings` object.
+
+### Tmux Prefix
+
+For users who want one terminal-style shortcut namespace and accept that `ctrl+b` starts a cmux chord instead of going directly to the shell.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.newSurface '["ctrl+b","c"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.closeTab '["ctrl+b","x"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSurface '["ctrl+b","n"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSurface '["ctrl+b","p"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.selectSurfaceByNumber '["ctrl+b","1"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.splitRight '["ctrl+b","v"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.splitDown '["ctrl+b","s"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusLeft '["ctrl+b","h"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusDown '["ctrl+b","j"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusUp '["ctrl+b","k"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRight '["ctrl+b","l"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleSplitZoom '["ctrl+b","z"]'
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleTerminalCopyMode '["ctrl+b","["]'
+"$CMUX_SETTINGS" set shortcuts.bindings.equalizeSplits '["ctrl+b","="]'
+```
+
+### macOS Terminal/iTerm Restore
+
+For users who want surface, split, and tab behavior to feel like common macOS terminals again. These actions already match cmux built-in defaults when no Settings UI override exists, so unset file overrides instead of writing default values.
+
+```bash
+"$CMUX_SETTINGS" unset shortcuts.bindings.newSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.closeTab
+"$CMUX_SETTINGS" unset shortcuts.bindings.nextSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.prevSurface
+"$CMUX_SETTINGS" unset shortcuts.bindings.selectSurfaceByNumber
+"$CMUX_SETTINGS" unset shortcuts.bindings.splitRight
+"$CMUX_SETTINGS" unset shortcuts.bindings.splitDown
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleSplitZoom
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleTerminalCopyMode
+"$CMUX_SETTINGS" unset shortcuts.bindings.renameTab
+```
+
+### Vim Pane Navigation
+
+For users who want fast pane movement without a prefix and do not want to depend on arrow keys.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.focusLeft cmd+opt+h
+"$CMUX_SETTINGS" set shortcuts.bindings.focusDown cmd+opt+j
+"$CMUX_SETTINGS" set shortcuts.bindings.focusUp cmd+opt+k
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRight cmd+opt+l
+"$CMUX_SETTINGS" set shortcuts.bindings.splitRight cmd+opt+v
+"$CMUX_SETTINGS" set shortcuts.bindings.splitDown cmd+opt+s
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleSplitZoom cmd+opt+z
+"$CMUX_SETTINGS" set shortcuts.bindings.equalizeSplits cmd+opt+=
+```
+
+### Agent Triage
+
+For users who live in notifications and want unread handling on one key family. This keeps toggle unread on `cmd+opt+u` so it can be combined with Vim Pane Navigation without colliding with `cmd+opt+j`.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.showNotifications cmd+u
+"$CMUX_SETTINGS" set shortcuts.bindings.jumpToUnread cmd+j
+"$CMUX_SETTINGS" set shortcuts.bindings.markOldestUnreadAndJumpNext cmd+shift+j
+"$CMUX_SETTINGS" set shortcuts.bindings.toggleUnread cmd+opt+u
+"$CMUX_SETTINGS" set shortcuts.bindings.triggerFlash cmd+shift+h
+"$CMUX_SETTINGS" set shortcuts.bindings.focusRightSidebar cmd+shift+e
+```
+
+### Workspace And Surface Lanes
+
+For users who want workspaces and surfaces on distinct number and bracket lanes.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.selectWorkspaceByNumber cmd+1
+"$CMUX_SETTINGS" set shortcuts.bindings.selectSurfaceByNumber cmd+opt+1
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSidebarTab 'cmd+opt+]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSidebarTab 'cmd+opt+['
+"$CMUX_SETTINGS" set shortcuts.bindings.nextSurface 'cmd+shift+]'
+"$CMUX_SETTINGS" set shortcuts.bindings.prevSurface 'cmd+shift+['
+```
+
+### Browser Defaults Restore
+
+For users who changed too much and want embedded-browser behavior to match common macOS browser shortcuts again. Use `unset` to clear file overrides so future cmux defaults still apply when no Settings UI override exists.
+
+```bash
+"$CMUX_SETTINGS" unset shortcuts.bindings.openBrowser
+"$CMUX_SETTINGS" unset shortcuts.bindings.focusBrowserAddressBar
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserBack
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserForward
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserReload
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomIn
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomOut
+"$CMUX_SETTINGS" unset shortcuts.bindings.browserZoomReset
+"$CMUX_SETTINGS" unset shortcuts.bindings.toggleBrowserDeveloperTools
+"$CMUX_SETTINGS" unset shortcuts.bindings.showBrowserJavaScriptConsole
+"$CMUX_SETTINGS" unset shortcuts.bindings.find
+"$CMUX_SETTINGS" unset shortcuts.bindings.findNext
+"$CMUX_SETTINGS" unset shortcuts.bindings.findPrevious
+```
+
+### Terminal-First Cleanup
+
+For users who want fewer app-level shortcuts. Prefer unbinding only the actions they name, but this is a reasonable starting proposal.
+
+```bash
+"$CMUX_SETTINGS" set shortcuts.bindings.renameTab null
+"$CMUX_SETTINGS" set shortcuts.bindings.renameWorkspace null
+"$CMUX_SETTINGS" set shortcuts.bindings.editWorkspaceDescription null
+"$CMUX_SETTINGS" set shortcuts.bindings.triggerFlash null
+"$CMUX_SETTINGS" set shortcuts.bindings.sendFeedback null
+```
+
+## Rules
+
+- Do not edit `~/.config/cmux/settings.json` unless the user explicitly asks. It is legacy fallback config.
+- Do not overwrite all of `shortcuts.bindings` unless the user explicitly wants a full replacement.
+- Do not invent action IDs. Validate against the schema or `shortcut-actions.md`.
+- Do not apply a broad template without showing the changed actions first unless the user explicitly said to apply that named template.
+- Do not promise conflict detection from `cmux-settings validate`; it validates JSON and supported keys, not shortcut syntax, macOS reservation, or every focus-context conflict.
+- Before assigning `cmd+[` or `cmd+]` to application-scoped actions, warn that they collide with common browser Back/Forward behavior unless the browser actions are also changed or unbound.
+- Prefer `unset` to clear file-managed overrides for individual actions. Do not call this a built-in default reset unless Settings UI/UserDefaults values have also been reset:
+
+  ```bash
+  "$CMUX_SETTINGS" unset shortcuts.bindings.focusLeft
+  "$CMUX_SETTINGS" validate
+  ```

--- a/.agents/skills/cmux-keyboard-shortcuts/agents/openai.yaml
+++ b/.agents/skills/cmux-keyboard-shortcuts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Keyboard Shortcuts"
+  short_description: "Customize cmux shortcuts and preset layouts."
+  default_prompt: "Use this skill to help choose and apply cmux keyboard shortcut templates: inspect current bindings, propose layouts, apply selected action paths, validate cmux.json, and report exact revert commands."

--- a/.agents/skills/cmux-localization/SKILL.md
+++ b/.agents/skills/cmux-localization/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: cmux-localization
+description: "Localization rules and audit workflow for cmux UI strings, settings rows, menus, shortcuts, schema/config text, docs, command/help text, alerts, tooltips, and web messages. Use whenever changing user-facing text."
+---
+
+# cmux Localization
+
+Use this skill for any user-facing string change.
+
+## Hard rules
+
+- All user-facing strings must be localized.
+- Use `String(localized: "key.name", defaultValue: "English text")` for Swift/AppKit/SwiftUI strings.
+- Keys go in `Resources/Localizable.xcstrings` with translations for all supported languages, currently English and Japanese.
+- Never use bare string literals in SwiftUI `Text()`, `Button()`, alert titles, tooltips, menus, or dialogs.
+- Localization audit is required for every user-facing change.
+- `defaultValue`, English fallback text, schema descriptions, or copied English strings do not count as localization.
+- For localized web/docs content, update every supported message catalog, currently `web/messages/en.json` and `web/messages/ja.json`, plus any localized data structures carrying inline translations.
+
+## Audit checklist
+
+Before finishing a task that changes UI, Settings rows, menus, shortcut metadata, schema/config text, docs, command/help text, alerts, or tooltips:
+
+1. Enumerate the changed user-facing surfaces.
+2. Verify each surface has entries for every supported locale.
+3. Parse touched localization files.
+4. Compare changed message keys across locales.
+5. Use `rg` over changed Swift/TS/TSX/docs files for newly introduced bare English.
+6. State the localization audit in the final handoff, or explicitly say what could not be verified.
+
+## Related shortcut rule
+
+Every new cmux-owned keyboard shortcut must be added to `KeyboardShortcutSettings`, visible/editable in Settings, supported in `~/.config/cmux/cmux.json`, and documented in the keyboard shortcut and configuration docs.
+
+## Detailed reference
+
+- Read [references/audit-workflow.md](references/audit-workflow.md) for a deeper audit process, common false positives, and examples of surfaces that count as user-facing.

--- a/.agents/skills/cmux-localization/agents/openai.yaml
+++ b/.agents/skills/cmux-localization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Localization"
+  short_description: "Localize and audit every cmux user-facing string change."
+  default_prompt: "Use this skill whenever changing cmux UI text, settings labels, menu items, shortcut metadata, schema/config text, docs, command/help output, alerts, tooltips, or web messages."

--- a/.agents/skills/cmux-localization/references/audit-workflow.md
+++ b/.agents/skills/cmux-localization/references/audit-workflow.md
@@ -1,0 +1,68 @@
+# Localization Audit Workflow
+
+This reference expands the localization rules for cmux.
+
+## What counts as user-facing
+
+Treat text as user-facing if it can appear in:
+
+- SwiftUI views
+- AppKit menus and dialogs
+- alerts and confirmation sheets
+- tooltips and accessibility labels
+- Settings rows and descriptions
+- command palette entries
+- keyboard shortcut metadata
+- CLI help or command output
+- JSON schema descriptions shown in docs or editors
+- docs pages
+- web UI
+- generated configuration examples shown to users
+
+Internal debug-only labels may still deserve localization if they are visible in the Debug menu or a debug window used by contributors.
+
+## Swift and AppKit
+
+Use:
+
+```swift
+String(localized: "key.name", defaultValue: "English text")
+```
+
+Update `Resources/Localizable.xcstrings` for all supported languages. Currently that means English and Japanese.
+
+Do not rely on `defaultValue` as the English localization. It is a fallback and development convenience, not a completed localization entry.
+
+## Web and docs
+
+For localized web/docs content, update:
+
+- `web/messages/en.json`
+- `web/messages/ja.json`
+- any localized data structures with inline translations
+
+Keep keys aligned across locales. A key added only to English is incomplete even if the UI falls back at runtime.
+
+## Bare English search
+
+After changing Swift, TS, TSX, or docs files, search the changed files for newly introduced user-facing English. Useful patterns include:
+
+```bash
+git diff --name-only -- '*.swift' '*.ts' '*.tsx' '*.md'
+rg 'Text\\("[A-Z][^"]+"' -- '*.swift'
+rg 'Button\\("[A-Z][^"]+"' -- '*.swift'
+rg 'tooltip|alert|title|description|label' -- '*.swift' '*.ts' '*.tsx'
+```
+
+These searches are not proof by themselves. They are prompts to inspect likely user-facing strings.
+
+## Final handoff
+
+Every UI/text-affecting final handoff should state:
+
+- which surfaces changed
+- which localization files were updated
+- which audit commands or manual checks were run
+- anything that could not be verified
+
+If no user-facing strings changed, say that clearly.

--- a/.agents/skills/cmux-markdown/SKILL.md
+++ b/.agents/skills/cmux-markdown/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: cmux-markdown
+description: Open markdown files in a formatted viewer panel with live reload. Use when you need to display plans, documentation, or notes alongside the terminal with rich rendering (headings, code blocks, tables, lists).
+---
+
+# Markdown Viewer with cmux
+
+Use this skill to display markdown files in a dedicated panel with rich formatting and live file watching.
+
+## Core Workflow
+
+1. Write your plan or notes to a `.md` file.
+2. Open it in a markdown panel.
+3. The panel auto-updates when the file changes on disk.
+
+```bash
+# Open a markdown file as a split panel next to the current terminal
+cmux markdown open plan.md
+
+# Absolute path
+cmux markdown open /path/to/PLAN.md
+
+# Target a specific workspace
+cmux markdown open design.md --workspace workspace:2
+```
+
+## When to Use
+
+- Displaying an agent plan or task list alongside the terminal
+- Showing documentation, changelogs, or READMEs while working
+- Reviewing notes that update in real-time (e.g., a plan file being written by another process)
+
+## Live File Watching
+
+The panel automatically re-renders when the file changes on disk. This works with:
+
+- Direct writes (`echo "..." >> plan.md`)
+- Editor saves (vim, nano, VS Code)
+- Atomic file replacement (write to temp, rename over original)
+- Agent-generated plan files that are updated progressively
+
+If the file is deleted, the panel shows a "file unavailable" state. During atomic replace, the panel attempts automatic reconnection within its short retry window. If the file returns later, close and reopen the panel.
+
+## Agent Integration
+
+### Opening a plan file
+
+Write your plan to a file, then open it:
+
+```bash
+cat > plan.md << 'EOF'
+# Task Plan
+
+## Steps
+1. Analyze the codebase
+2. Implement the feature
+3. Write tests
+4. Verify the build
+EOF
+
+cmux markdown open plan.md
+```
+
+### Updating a plan in real-time
+
+The panel live-reloads, so simply overwrite the file as work progresses:
+
+```bash
+# The markdown panel updates automatically when the file changes
+echo "## Step 1: Complete" >> plan.md
+```
+
+### Recommended AGENTS.md instruction
+
+Add this to your project's `AGENTS.md` to instruct coding agents to use the markdown viewer:
+
+```markdown
+## Plan Display
+
+When creating a plan or task list, write it to a `.md` file and open it in cmux:
+
+    cmux markdown open plan.md
+
+The panel renders markdown with rich formatting and auto-updates when the file changes.
+```
+
+## Routing
+
+```bash
+# Open in the caller's workspace (default -- uses CMUX_WORKSPACE_ID)
+cmux markdown open plan.md
+
+# Open in a specific workspace
+cmux markdown open plan.md --workspace workspace:2
+
+# Open splitting from a specific surface
+cmux markdown open plan.md --surface surface:5
+
+# Open in a specific window
+cmux markdown open plan.md --window window:1
+```
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full command syntax and options |
+| [references/live-reload.md](references/live-reload.md) | File watching behavior, atomic writes, edge cases |
+
+## Rendering Support
+
+The markdown panel renders:
+
+- Headings (h1-h6) with dividers on h1/h2
+- Fenced code blocks with monospaced font
+- Inline code with highlighted background
+- Tables with alternating row colors
+- Ordered and unordered lists (nested)
+- Blockquotes with left border
+- Bold, italic, strikethrough
+- Links (clickable)
+- Horizontal rules
+- Images (inline)
+
+Supports both light and dark mode.

--- a/.agents/skills/cmux-markdown/agents/openai.yaml
+++ b/.agents/skills/cmux-markdown/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Markdown Viewer"
+  short_description: "Open markdown files in a formatted panel with live reload alongside the terminal."
+  default_prompt: "Use this skill to display markdown plans, docs, or notes in a cmux panel: write to a .md file, run 'cmux markdown open <path>', and the panel auto-updates when the file changes."

--- a/.agents/skills/cmux-markdown/references/commands.md
+++ b/.agents/skills/cmux-markdown/references/commands.md
@@ -1,0 +1,69 @@
+# Command Reference (cmux Markdown)
+
+## Opening a Markdown Panel
+
+```bash
+cmux markdown open <path>
+cmux markdown <path>          # shorthand (implicit "open")
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--workspace <id\|ref\|index>` | Target workspace | `$CMUX_WORKSPACE_ID` |
+| `--surface <id\|ref\|index>` | Source surface to split from | Focused surface |
+| `--window <id\|ref>` | Target window | Current window |
+
+### Output
+
+```
+OK surface=surface:8 pane=pane:3 path=/absolute/path/to/file.md
+```
+
+With `--json`:
+
+```json
+{
+  "window_id": "...",
+  "workspace_id": "...",
+  "pane_id": "...",
+  "surface_id": "...",
+  "path": "/absolute/path/to/file.md"
+}
+```
+
+## Path Resolution
+
+- Relative paths are resolved against the caller's current working directory.
+- `~` is expanded to the home directory.
+- The resolved absolute path is returned in the output.
+
+```bash
+# These are equivalent when run from /Users/me/project
+cmux markdown open plan.md
+cmux markdown open ./plan.md
+cmux markdown open /Users/me/project/plan.md
+```
+
+## Panel Behavior
+
+- The panel opens as a **horizontal split** to the right of the source surface.
+- The tab title shows the filename (e.g., `plan.md`).
+- The tab icon is a document icon.
+- Content is **read-only** with text selection enabled.
+- The file path is displayed as a breadcrumb at the top of the panel.
+
+## Session Persistence
+
+Markdown panels are saved and restored across sessions. On restore, the panel re-reads the file from disk. If the file no longer exists at restore time, the panel is not recreated.
+
+## Help
+
+```bash
+cmux markdown --help
+cmux markdown -h
+```
+
+See also:
+- [live-reload.md](live-reload.md)

--- a/.agents/skills/cmux-markdown/references/live-reload.md
+++ b/.agents/skills/cmux-markdown/references/live-reload.md
@@ -1,0 +1,53 @@
+# Live Reload Behavior
+
+The markdown panel watches the file on disk and automatically re-renders when it changes. This enables real-time plan tracking as agents or editors update the file.
+
+## How It Works
+
+The panel uses a kernel-level file system watcher (`DispatchSource` with `O_EVTONLY`) that monitors the file for:
+
+- **Write events** -- content was modified in place
+- **Extend events** -- content was appended
+- **Delete events** -- file was removed (atomic replace step 1)
+- **Rename events** -- file was moved or renamed
+
+## Supported Write Patterns
+
+| Pattern | Supported | Notes |
+|---------|-----------|-------|
+| Direct write (`echo >>`) | Yes | Triggers write/extend event |
+| Editor save (vim, nano) | Yes | Most editors use atomic write (see below) |
+| Atomic replace (write tmp + rename) | Yes | Handled via delete/rename recovery |
+| `sed -i` | Yes | Uses atomic replace internally |
+| VS Code / IDE save | Yes | Uses atomic replace |
+| Agent progressive writes | Yes | Each write triggers a re-render |
+
+## Atomic File Replacement
+
+Many editors and tools write files atomically: write to a temporary file, then rename it over the original. This shows up as a **delete** event followed by a new file appearing at the same path.
+
+The panel handles this by:
+
+1. Detecting the delete/rename event
+2. Attempting to re-read the file immediately (in case the rename already happened)
+3. If the file is missing, wait 500 ms and check again (the new file may not yet be in place)
+4. Reconnecting the file watcher to the new inode
+
+## File Unavailable State
+
+If the file is deleted and does not reappear within the retry window, the panel shows a "file unavailable" state with the original path. The panel does not close automatically -- the user must close it manually.
+
+If the file later reappears at the same path (e.g., the user recreates it), the panel does NOT automatically reconnect. Close and reopen the panel to pick up the new file.
+
+## Performance
+
+- Re-reads are dispatched to the main thread and run synchronously.
+- Large files (100KB+) may cause brief UI hitches during re-render. For extremely large markdown files, consider splitting into smaller documents.
+- The file watcher runs on a low-priority background queue and has negligible CPU impact.
+
+## Tips for Agents
+
+- **Write the full plan file first, then open it.** This avoids the panel showing a partially written file.
+- **Append-style updates work well.** Adding sections to the end of a file triggers a smooth re-render.
+- **Overwriting the entire file is fine.** The atomic replace handling ensures no data is lost.
+- **Don't delete and recreate rapidly.** If writing a new version, prefer overwriting in place or using atomic replacement.

--- a/.agents/skills/cmux-release/SKILL.md
+++ b/.agents/skills/cmux-release/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: cmux-release
+description: "cmux release workflow, version bumping, changelog updates, pretag guard, release tags, and release asset expectations. Use when preparing or troubleshooting a cmux release."
+---
+
+# cmux Release
+
+Use the `/release` command to prepare a new release. This will:
+
+1. Determine the new version (bumps minor by default)
+2. Gather commits since the last tag and update the changelog
+3. Update `CHANGELOG.md` (the docs changelog page at `web/app/docs/changelog/page.tsx` reads from it)
+4. Run `./scripts/bump-version.sh` to update both versions
+5. Commit, run `./scripts/release-pretag-guard.sh`, tag, and push
+
+## Version bumping
+
+```bash
+./scripts/bump-version.sh
+./scripts/bump-version.sh patch
+./scripts/bump-version.sh major
+./scripts/bump-version.sh 1.0.0
+```
+
+This updates both `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`. The build number is auto-incremented and is required for Sparkle auto-update to work.
+
+Before creating a release tag, run:
+
+```bash
+./scripts/release-pretag-guard.sh
+```
+
+If it fails, run `./scripts/bump-version.sh`, commit the build-number bump, then retry tagging.
+
+Manual release steps if not using the command:
+
+```bash
+./scripts/release-pretag-guard.sh
+git tag vX.Y.Z
+git push origin vX.Y.Z
+gh run watch --repo manaflow-ai/cmux
+```
+
+## Notes
+
+- Requires GitHub secrets: `APPLE_CERTIFICATE_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`.
+- The release asset is `cmux-macos.dmg` attached to the tag.
+- README download button points to `releases/latest/download/cmux-macos.dmg`.
+- Bump the minor version for updates unless explicitly asked otherwise.
+- Update `CHANGELOG.md`; docs changelog is rendered from it.
+
+## Detailed reference
+
+- Read [references/release-checklist.md](references/release-checklist.md) for a more detailed release checklist and common failure handling.

--- a/.agents/skills/cmux-release/agents/openai.yaml
+++ b/.agents/skills/cmux-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Release"
+  short_description: "Prepare cmux releases with version, changelog, guard, tag, and asset rules."
+  default_prompt: "Use this skill when preparing a cmux release, bumping versions, updating CHANGELOG.md, running the release pretag guard, tagging, or troubleshooting release assets."

--- a/.agents/skills/cmux-release/references/release-checklist.md
+++ b/.agents/skills/cmux-release/references/release-checklist.md
@@ -1,0 +1,77 @@
+# Release Checklist
+
+This reference expands the cmux release workflow.
+
+## Default path
+
+Prefer the `/release` command. It should handle:
+
+- choosing the version
+- gathering commits since the last tag
+- updating `CHANGELOG.md`
+- running `./scripts/bump-version.sh`
+- committing release metadata
+- running `./scripts/release-pretag-guard.sh`
+- tagging and pushing
+
+## Version policy
+
+Use a minor bump by default. Use patch or major only when explicitly requested or clearly justified by the release scope.
+
+The version bump script updates both:
+
+- `MARKETING_VERSION`
+- `CURRENT_PROJECT_VERSION`
+
+The build number must increase for Sparkle auto-update. If `release-pretag-guard.sh` fails because the build number is not monotonic, run the bump script, commit the build-number bump, and retry the guard.
+
+## Changelog
+
+Update `CHANGELOG.md`. The docs changelog page at `web/app/docs/changelog/page.tsx` renders from it, so do not update a separate docs changelog source.
+
+Keep the changelog user-facing. Mention user-visible fixes, behavior changes, and compatibility notes more prominently than internal refactors.
+
+## Tagging
+
+Run before tagging:
+
+```bash
+./scripts/release-pretag-guard.sh
+```
+
+Manual tag flow:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+gh run watch --repo manaflow-ai/cmux
+```
+
+## Release asset
+
+The expected release asset is:
+
+```text
+cmux-macos.dmg
+```
+
+The README download button points to:
+
+```text
+releases/latest/download/cmux-macos.dmg
+```
+
+If the asset name changes, update every surface that assumes this path.
+
+## Required secrets
+
+Release signing/notarization depends on:
+
+- `APPLE_CERTIFICATE_BASE64`
+- `APPLE_CERTIFICATE_PASSWORD`
+- `APPLE_SIGNING_IDENTITY`
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `APPLE_TEAM_ID`
+
+If release automation fails before signing, inspect workflow configuration and version metadata first. If it fails during signing/notarization, inspect the secret availability and Apple account status.

--- a/.agents/skills/cmux-settings/SKILL.md
+++ b/.agents/skills/cmux-settings/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: cmux-settings
+description: "View and edit cmux settings in ~/.config/cmux/cmux.json. Use when the user wants to change cmux preferences (appearance, sidebar, notifications, automation, browser, shortcuts), set a value by JSON path, validate the file, open it in an editor, or look up which keys cmux recognizes. Triggers on '/cmux-settings', 'change cmux setting', 'set <something> in cmux', 'cmux config', 'cmux.json', or 'rebind a cmux shortcut'."
+---
+
+# cmux-settings
+
+cmux reads user settings from `~/.config/cmux/cmux.json` (JSONC). The app installs a file watcher; saving the file applies changes immediately, no restart needed. Legacy `~/.config/cmux/settings.json` is read only as a fallback for keys not present in `cmux.json`.
+
+Schema: `https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json`. The authoritative path list lives in `Sources/CmuxSettingsJSONPathSupport.swift` in the cmux checkout, and the installed skill includes a generated copy in `references/all-keys.md`. Top-level sections are `app`, `terminal`, `notifications`, `sidebar`, `sidebarAppearance`, `workspaceColors`, `automation`, `browser`, and `shortcuts`. Non-settings sections (`actions`, `ui`, `commands`, `vault`, `rightSidebar`) coexist in the same file.
+
+## Helper script
+
+Use the bundled helper for every read/write. It strips JSONC comments, writes atomically, and validates keys against the schema.
+
+```bash
+# From a cmux checkout
+skills/cmux-settings/scripts/cmux-settings <subcommand>
+
+# From an installed Codex skill
+~/.codex/skills/cmux-settings/scripts/cmux-settings <subcommand>
+```
+
+For brevity in the rest of this doc, assume the script is on `$PATH` as `cmux-settings`. To make it so for a session from a checkout: `export PATH="$PWD/skills/cmux-settings/scripts:$PATH"`.
+
+Subcommands:
+
+| Command | What it does |
+|---|---|
+| `cmux-settings path` | Print the config path. |
+| `cmux-settings dump` | Print the raw file (preserves comments). |
+| `cmux-settings dump --no-comments` | Print the parsed JSON. |
+| `cmux-settings get <a.b.c>` | Print value at dotted JSON path. |
+| `cmux-settings set <a.b.c> <value>` | Set value. `<value>` is parsed as JSON (`true`, `42`, `"text"`, `[…]`, `{…}`); plain strings without quotes are stored as strings. |
+| `cmux-settings unset <a.b.c>` | Delete key, reverting to the in-app default. |
+| `cmux-settings list-supported` | List every settings JSON path the app recognizes. |
+| `cmux-settings validate` | Parse the file and flag any unknown settings keys. |
+| `cmux-settings open` | Open `cmux.json` in `$EDITOR`, VS Code, Cursor, or TextEdit. |
+
+`--file <path>` overrides the target file (useful for `--file ~/.config/cmux/settings.json` when the user keeps things in the legacy file).
+
+## Workflow
+
+1. Confirm the change. If the user named a setting in plain English (e.g. "make the sidebar tint match the terminal background"), look it up first.
+   ```bash
+   cmux-settings list-supported | rg -i 'sidebar.*terminal|terminal.*sidebar'
+   ```
+2. Set the value. JSON literals (`true`, `false`, numbers, arrays, objects) must be valid JSON. Plain words are stored as strings.
+   ```bash
+   cmux-settings set sidebarAppearance.matchTerminalBackground true
+   cmux-settings set app.appearance dark
+   cmux-settings set shortcuts.bindings.toggleSidebar cmd+b
+   cmux-settings set shortcuts.bindings.newTab '["ctrl+b","c"]'
+   cmux-settings set browser.hostsToOpenInEmbeddedBrowser '["localhost","*.internal.example"]'
+   ```
+3. Verify by reading back and validating.
+   ```bash
+   cmux-settings get sidebarAppearance.matchTerminalBackground
+   cmux-settings validate
+   ```
+4. Tell the user it auto-reloaded. No app restart. If they want to revert, run `cmux-settings unset <key>`.
+
+## Quick reference
+
+- Appearance: `app.appearance` = `"system" | "light" | "dark"`, `app.appIcon`, `app.menuBarOnly`, `app.minimalMode`.
+- Sidebar tint: `sidebarAppearance.matchTerminalBackground`, `sidebarAppearance.tintColor`, `sidebarAppearance.tintOpacity` (0..1).
+- Sidebar details: `sidebar.hideAllDetails`, `sidebar.showBranchDirectory`, `sidebar.showPullRequests`, `sidebar.showPorts`, `sidebar.showLog`.
+- Notifications: `notifications.dockBadge`, `notifications.sound` (enum incl. `"none"`, `"custom_file"`), `notifications.customSoundFilePath`, `notifications.hooks` (array).
+- Browser: `browser.defaultSearchEngine`, `browser.theme`, `browser.openTerminalLinksInCmuxBrowser`, `browser.hostsToOpenInEmbeddedBrowser`.
+- Automation: `automation.socketControlMode` (`off | cmuxOnly | automation | password | allowAll`), `automation.portBase`, `automation.portRange`.
+- Shortcuts: `shortcuts.bindings.<actionId>` = `"cmd+b"`, `["ctrl+b","c"]`, `null`, or `""` to unbind. See `references/shortcut-actions.md`.
+
+For the full list of settings, defaults, and descriptions, run `cmux-settings list-supported` or read [references/all-keys.md](references/all-keys.md).
+
+## Rules
+
+- Only edit `cmux.json`. Never edit `settings.json` unless the user explicitly asks; it is legacy and only read when the key is absent from `cmux.json`.
+- Never tell the user to restart cmux to apply a change. The file watcher reloads on save.
+- Always validate after a bulk edit: `cmux-settings validate`. Unknown keys mean the user pasted a key the app does not consume.
+- Do not blindly overwrite top-level sections (`actions`, `ui`, `commands`, `vault`, `rightSidebar`). They live in the same file and contain non-settings config the user has hand-tuned.
+- Shortcut action ids must match the schema enum. Look them up in [references/shortcut-actions.md](references/shortcut-actions.md) before binding.
+- Color values must be `#RRGGBB`. Opacities are `0..1`.
+- For settings the user expressed in app-level language (e.g. "Settings > Notifications > Dock badge"), translate to the matching JSON path first; the docs page at `web/app/[locale]/docs/configuration/page.tsx` mirrors the schema 1:1.

--- a/.agents/skills/cmux-settings/agents/openai.yaml
+++ b/.agents/skills/cmux-settings/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Settings"
+  short_description: "Inspect, edit, validate, and reload cmux.json settings."
+  default_prompt: "Use this skill to change cmux settings safely: map user-facing preferences to cmux.json paths, edit with the bundled helper, validate recognized keys, and rely on cmux's live config reload."

--- a/.agents/skills/cmux-settings/references/all-keys.md
+++ b/.agents/skills/cmux-settings/references/all-keys.md
@@ -1,0 +1,140 @@
+# All settings keys
+
+Auto-generated from `web/data/cmux.schema.json`. For the rendered docs, see `https://cmux.com/docs/configuration`.
+
+## app
+
+General app preferences from Settings > App.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `app.language` | `"system"` or `"en"` or `"ar"` or `"bs"` or `"zh-Hans"` or `"zh-Hant"` or `"da"` or `"de"` or `"es"` or `"fr"` or `"it"` or `"ja"` or `"ko"` or `"nb"` or `"pl"` or `"pt-BR"` or `"ru"` or `"th"` or `"tr"` | `"system"` | Preferred app language. |
+| `app.appearance` | `"system"` or `"light"` or `"dark"` | `"system"` | App appearance mode. |
+| `app.appIcon` | `"automatic"` or `"light"` or `"dark"` | `"automatic"` | Dock and app switcher icon style. |
+| `app.menuBarOnly` | boolean | `false` | Hide the Dock icon and app switcher entry while keeping cmux available from the menu bar. |
+| `app.newWorkspacePlacement` | `"top"` or `"afterCurrent"` or `"end"` | `"afterCurrent"` | Where new workspaces are inserted in the sidebar. |
+| `app.workspaceInheritWorkingDirectory` | boolean | `true` | When true, new workspaces inherit the current workspace working directory. When false, new workspaces leave the working directory unset so Ghostty's working-directory setting can provide the default. |
+| `app.minimalMode` | boolean | `false` | Hide the workspace title bar and move controls into the sidebar. |
+| `app.keepWorkspaceOpenWhenClosingLastSurface` | boolean | `false` | When true, closing the last surface keeps the workspace open. |
+| `app.focusPaneOnFirstClick` | boolean | `true` | When cmux is inactive, the first click can activate and focus the clicked pane. |
+| `app.preferredEditor` | string | `""` | Custom editor command used when Cmd-click file previews are disabled or a file is unsupported. Leave empty to use the default. |
+| `app.openSupportedFilesInCmux` | boolean | `true` | When enabled, Cmd-clicking readable local files opens supported previews in cmux, including text, code, PDFs, images, audio, video, and Quick Look files. Preview headers include an Open With menu based on the user's default and compatible macOS apps for that file. |
+| `app.openMarkdownInCmuxViewer` | boolean | `true` | When enabled, Cmd-clicking .md/.markdown/.mkd/.mdx files opens the rendered cmux markdown viewer panel (with live reload) instead of the generic file preview. |
+| `app.reorderOnNotification` | boolean | `true` | Move workspaces with new notifications toward the top. |
+| `app.iMessageMode` | boolean | `false` | Move a workspace to the top and show the submitted message when sending an agent prompt. |
+| `app.sendAnonymousTelemetry` | boolean | `true` | Allow anonymous telemetry. |
+| `app.warnBeforeQuit` | boolean | `true` | Show a confirmation before quitting cmux. |
+| `app.warnBeforeClosingTab` | boolean | `true` | Show a confirmation before closing a tab. |
+| `app.renameSelectsExistingName` | boolean | `true` | Select the current name when opening rename flows. |
+| `app.commandPaletteSearchesAllSurfaces` | boolean | `false` | Search every surface in the command palette switcher instead of only the active workspace. |
+
+## terminal
+
+Terminal presentation settings from Settings > Terminal.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `terminal.showScrollBar` | boolean | `true` | Show the right-edge terminal scroll bar when scrollback is available. cmux automatically suppresses it for alternate-screen style TUI surfaces. |
+| `terminal.autoResumeAgentSessions` | boolean | `true` | Automatically run agent resume commands for restored terminal sessions when cmux reopens after quit. Set false to restore panes while keeping Claude Code, Codex, OpenCode, and other saved agent sessions idle until you resume them manually. |
+
+## notifications
+
+Notification behavior from Settings > Notifications.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `notifications.dockBadge` | boolean | `true` | Show the unread count in the Dock tile. |
+| `notifications.showInMenuBar` | boolean | `true` | Show the menu bar extra. |
+| `notifications.unreadPaneRing` | boolean | `true` | Highlight panes with unread notifications. |
+| `notifications.paneFlash` | boolean | `true` | Flash the focused pane when requested. |
+| `notifications.sound` | `"default"` or `"Basso"` or `"Blow"` or `"Bottle"` or `"Frog"` or `"Funk"` or `"Glass"` or `"Hero"` or `"Morse"` or `"Ping"` or `"Pop"` or `"Purr"` or `"Sosumi"` or `"Submarine"` or `"Tink"` or `"custom_file"` or `"none"` | `"default"` | Notification sound preset. |
+| `notifications.customSoundFilePath` | string | `""` | Local path to the custom notification sound file. |
+| `notifications.command` | string | `""` | Optional shell command to run alongside notification delivery. |
+| `notifications.hooksMode` | `"append"` or `"replace"` | `"append"` | Controls whether project-local notification hooks append to inherited hooks or replace them. |
+| `notifications.hooks` | array<object> | `[]` | Composable shell hooks that receive notification policy JSON on stdin and return updated policy JSON on stdout. |
+
+## sidebar
+
+Sidebar content and metadata visibility from Settings > Sidebar.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `sidebar.hideAllDetails` | boolean | `false` | Hide all per-workspace detail rows. |
+| `sidebar.showWorkspaceDescription` | boolean | `true` | Show custom workspace descriptions in the sidebar. |
+| `sidebar.branchLayout` | `"vertical"` or `"inline"` | `"vertical"` | Show git branch details stacked vertically or inline. |
+| `sidebar.showNotificationMessage` | boolean | `true` | Show the latest notification text in the sidebar. |
+| `sidebar.showBranchDirectory` | boolean | `true` | Show the workspace working directory. |
+| `sidebar.showPullRequests` | boolean | `true` | Show pull request metadata in the sidebar. |
+| `sidebar.makePullRequestsClickable` | boolean | `true` | Allow sidebar pull request metadata to open links when clicked. |
+| `sidebar.openPullRequestLinksInCmuxBrowser` | boolean | `true` | Open sidebar pull request links in the embedded cmux browser. |
+| `sidebar.openPortLinksInCmuxBrowser` | boolean | `true` | Open sidebar port links in the embedded cmux browser. |
+| `sidebar.showSSH` | boolean | `true` | Show SSH connection details. |
+| `sidebar.showPorts` | boolean | `true` | Show listening ports. |
+| `sidebar.showLog` | boolean | `true` | Show recent log snippets. |
+| `sidebar.showProgress` | boolean | `true` | Show progress indicators. |
+| `sidebar.showCustomMetadata` | boolean | `true` | Show custom metadata pills. |
+
+## workspaceColors
+
+Workspace tab and badge colors from Settings > Workspace Colors.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `workspaceColors.indicatorStyle` | `"leftRail"` or `"solidFill"` or `"rail"` or `"border"` or `"wash"` or `"lift"` or `"typography"` or `"washRail"` or `"blueWashColorRail"` | `"leftRail"` | Active workspace indicator style. Legacy aliases are accepted and normalized. |
+| `workspaceColors.selectionColor` | colorHexOrNull | `null` | Override the selected workspace background color. |
+| `workspaceColors.notificationBadgeColor` | colorHexOrNull | `null` | Override the unread notification badge color. |
+| `workspaceColors.colors` | object | `{"Red": "#C0392B", "Crimson": "#922B21", "Orange": "#A04000", "Amber": "#7D6608", "Olive": "#4A5C18", "Green": "#196F3D", "Teal": "#006B6B", "Aqua": "#0E6B8C", "Blue": "#1565C0", "Navy": "#1A5276", "Indigo": "#283593", "Purple": "#6A1B9A", "Magenta": "#AD1457", "Rose": "#880E4F", "Brown": "#7B3F00", "Charcoal": "#3E4B5E"}` | Full named workspace color palette. Include built-in entries you want to keep, remove keys to remove colors, and add more named entries to extend the picker. |
+| `workspaceColors.paletteOverrides` | object | `{}` | Legacy workspace color overrides for built-in palette names. Prefer workspaceColors.colors for new configs. |
+| `workspaceColors.customColors` | array<colorHex> | `[]` | Legacy list of custom workspace colors. Prefer workspaceColors.colors for new configs. |
+
+## sidebarAppearance
+
+Sidebar tint settings from Settings > Sidebar Appearance.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `sidebarAppearance.matchTerminalBackground` | boolean | `false` | Use the terminal background instead of the sidebar tint. |
+| `sidebarAppearance.tintColor` | colorHex | `"#000000"` | Base sidebar tint color used when light/dark overrides are not set. |
+| `sidebarAppearance.lightModeTintColor` | colorHexOrNull | `null` | Sidebar tint override for light appearance. |
+| `sidebarAppearance.darkModeTintColor` | colorHexOrNull | `null` | Sidebar tint override for dark appearance. |
+| `sidebarAppearance.tintOpacity` | number | `0.03` | Sidebar tint opacity from 0 to 1. Note: this only controls the sidebar tint, not terminal/window transparency. For terminal background transparency or blur, set `background-opacity` and `background-blur` in `~/.config/ghostty/config` and run `cmux reload-config`. |
+
+## automation
+
+Socket control and automation settings from Settings > Automation.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `automation.socketControlMode` | `"off"` or `"cmuxOnly"` or `"automation"` or `"password"` or `"allowAll"` or `"openAccess"` or `"fullOpenAccess"` or `"notifications"` or `"full"` | `"cmuxOnly"` | Socket control mode. Legacy aliases are accepted and normalized. |
+| `automation.socketPassword` | string or null | `""` | Password for password-mode socket access. Use null or an empty string to clear it. |
+| `automation.claudeCodeIntegration` | boolean | `true` | Enable cmux integration hooks for Claude Code. |
+| `automation.claudeBinaryPath` | string | `""` | Custom path to the claude binary. |
+| `automation.cursorIntegration` | boolean | `true` | Enable cmux integration hooks for Cursor. |
+| `automation.geminiIntegration` | boolean | `true` | Enable cmux integration hooks for Gemini. |
+| `automation.portBase` | integer | `9100` | Starting value for workspace CMUX_PORT assignments. |
+| `automation.portRange` | integer | `10` | Number of ports reserved per workspace. |
+
+## browser
+
+Embedded browser settings from Settings > Browser.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `browser.defaultSearchEngine` | `"google"` or `"duckduckgo"` or `"bing"` or `"kagi"` or `"startpage"` | `"google"` | Default search engine for non-URL queries. |
+| `browser.showSearchSuggestions` | boolean | `true` | Show omnibar search suggestions. |
+| `browser.theme` | `"system"` or `"light"` or `"dark"` | `"system"` | Embedded browser theme. |
+| `browser.openTerminalLinksInCmuxBrowser` | boolean | `true` | Open clicked terminal links in the embedded browser. |
+| `browser.interceptTerminalOpenCommandInCmuxBrowser` | boolean | `true` | Intercept terminal open http(s) commands and route them through the embedded browser. |
+| `browser.hostsToOpenInEmbeddedBrowser` | array<string> | `[]` | Allowlist of hosts that should stay inside the embedded browser. |
+| `browser.urlsToAlwaysOpenExternally` | array<string> | `[]` | Rules that always open matching URLs in the system browser. |
+| `browser.insecureHttpHostsAllowedInEmbeddedBrowser` | array<string> | `["localhost", "*.localhost", "127.0.0.1", "::1", "0.0.0.0", "*.localtest.me"]` | HTTP hosts allowed in the embedded browser without a warning prompt. |
+| `browser.showImportHintOnBlankTabs` | boolean | `true` | Show the browser import hint on blank tabs. |
+| `browser.reactGrabVersion` | string | `"0.1.29"` | Pinned react-grab version for the browser toolbar helper. |
+
+## shortcuts
+
+Keyboard shortcut settings from Settings > Keyboard Shortcuts.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `shortcuts.bindings` | object | `{}` | Shortcut overrides keyed by cmux action id. Use a string for a single shortcut, an array for a chord, null, an empty string, none, clear, unbound, or disabled to unbind. |

--- a/.agents/skills/cmux-settings/references/shortcut-actions.md
+++ b/.agents/skills/cmux-settings/references/shortcut-actions.md
@@ -1,0 +1,113 @@
+# Keyboard shortcut action ids
+
+Auto-generated from `web/data/cmux.schema.json` (`shortcuts.bindings.propertyNames.enum`).
+
+Values for `shortcuts.bindings.<action>`:
+
+- A string like `"cmd+b"` for a single shortcut.
+- A two-element array like `["ctrl+b","c"]` for a chord.
+- `null` or an empty string (`""`, `"none"`, `"clear"`, `"unbound"`, `"disabled"`) to unbind.
+
+## App
+
+- `shortcuts.bindings.openSettings`
+- `shortcuts.bindings.reloadConfiguration`
+- `shortcuts.bindings.showHideAllWindows`
+- `shortcuts.bindings.globalSearch`
+- `shortcuts.bindings.newWindow`
+- `shortcuts.bindings.closeWindow`
+- `shortcuts.bindings.toggleFullScreen`
+- `shortcuts.bindings.quit`
+- `shortcuts.bindings.openFolder`
+- `shortcuts.bindings.sendFeedback`
+
+## Tabs
+
+- `shortcuts.bindings.newTab`
+- `shortcuts.bindings.newBrowserWorkspace`
+- `shortcuts.bindings.reopenPreviousSession`
+- `shortcuts.bindings.renameTab`
+- `shortcuts.bindings.closeTab`
+- `shortcuts.bindings.closeOtherTabsInPane`
+
+## Workspace
+
+- `shortcuts.bindings.goToWorkspace`
+- `shortcuts.bindings.selectWorkspaceByNumber`
+- `shortcuts.bindings.renameWorkspace`
+- `shortcuts.bindings.editWorkspaceDescription`
+- `shortcuts.bindings.closeWorkspace`
+
+## Panes and surfaces
+
+- `shortcuts.bindings.nextSurface`
+- `shortcuts.bindings.prevSurface`
+- `shortcuts.bindings.selectSurfaceByNumber`
+- `shortcuts.bindings.newSurface`
+- `shortcuts.bindings.toggleTerminalCopyMode`
+- `shortcuts.bindings.clearScreenKeepScrollback`
+- `shortcuts.bindings.focusLeft`
+- `shortcuts.bindings.focusRight`
+- `shortcuts.bindings.focusUp`
+- `shortcuts.bindings.focusDown`
+- `shortcuts.bindings.splitRight`
+- `shortcuts.bindings.splitDown`
+- `shortcuts.bindings.toggleSplitZoom`
+- `shortcuts.bindings.equalizeSplits`
+
+## Command palette
+
+- `shortcuts.bindings.commandPalette`
+- `shortcuts.bindings.commandPaletteNext`
+- `shortcuts.bindings.commandPalettePrevious`
+
+## Notifications
+
+- `shortcuts.bindings.showNotifications`
+- `shortcuts.bindings.jumpToUnread`
+- `shortcuts.bindings.toggleUnread`
+- `shortcuts.bindings.markOldestUnreadAndJumpNext`
+- `shortcuts.bindings.triggerFlash`
+
+## Right sidebar
+
+- `shortcuts.bindings.toggleSidebar`
+- `shortcuts.bindings.focusRightSidebar`
+- `shortcuts.bindings.switchRightSidebarToFiles`
+- `shortcuts.bindings.switchRightSidebarToFind`
+- `shortcuts.bindings.switchRightSidebarToSessions`
+- `shortcuts.bindings.switchRightSidebarToFeed`
+- `shortcuts.bindings.switchRightSidebarToDock`
+- `shortcuts.bindings.nextSidebarTab`
+- `shortcuts.bindings.prevSidebarTab`
+
+## Browser
+
+- `shortcuts.bindings.reopenClosedBrowserPanel`
+- `shortcuts.bindings.splitBrowserRight`
+- `shortcuts.bindings.splitBrowserDown`
+- `shortcuts.bindings.openBrowser`
+- `shortcuts.bindings.focusBrowserAddressBar`
+- `shortcuts.bindings.browserBack`
+- `shortcuts.bindings.browserForward`
+- `shortcuts.bindings.browserReload`
+- `shortcuts.bindings.browserZoomIn`
+- `shortcuts.bindings.browserZoomOut`
+- `shortcuts.bindings.browserZoomReset`
+- `shortcuts.bindings.toggleBrowserDeveloperTools`
+- `shortcuts.bindings.showBrowserJavaScriptConsole`
+
+## Find
+
+- `shortcuts.bindings.find`
+- `shortcuts.bindings.findInDirectory`
+- `shortcuts.bindings.findNext`
+- `shortcuts.bindings.findPrevious`
+- `shortcuts.bindings.hideFind`
+- `shortcuts.bindings.useSelectionForFind`
+
+## Files and React Grab
+
+- `shortcuts.bindings.toggleFileExplorer`
+- `shortcuts.bindings.saveFilePreview`
+- `shortcuts.bindings.toggleReactGrab`

--- a/.agents/skills/cmux-settings/scripts/cmux-settings
+++ b/.agents/skills/cmux-settings/scripts/cmux-settings
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Inspect and edit ~/.config/cmux/cmux.json.
+
+cmux watches the file and auto-reloads on save, so writes take effect
+immediately. The file is JSONC (JSON with // and /* */ comments); this
+script writes comment-free formatting (2-space indent, trailing newline)
+and only writes when the parsed value actually changes.
+
+Usage:
+  cmux-settings path                    print the config path
+  cmux-settings dump [--no-comments]    print current settings (raw or stripped)
+  cmux-settings get <dotted.path>       print value at path (JSON)
+  cmux-settings set <dotted.path> <v>   set value (v parsed as JSON, falls back to string)
+  cmux-settings unset <dotted.path>     remove value at path
+  cmux-settings list-supported          print every settings path the schema recognizes
+  cmux-settings validate                check JSON parses and all set keys are recognized
+  cmux-settings open                    open the file in $EDITOR (or VS Code, then TextEdit)
+
+Examples:
+  cmux-settings set app.appearance dark
+  cmux-settings set notifications.dockBadge false
+  cmux-settings set shortcuts.bindings.toggleSidebar '"cmd+b"'
+  cmux-settings set shortcuts.bindings.newTab '["ctrl+b","c"]'
+  cmux-settings unset app.appearance
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PATH = Path.home() / ".config" / "cmux" / "cmux.json"
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json"
+)
+
+
+def strip_jsonc(text: str) -> str:
+    """Remove // line comments and /* block comments outside strings."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    string_quote = ""
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = True
+            string_quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i + 2)
+            i = n if j == -1 else j
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            i = n if j == -1 else j + 2
+            continue
+        out.append(ch)
+        i += 1
+    # Drop trailing commas before ] or } (also legal in JSONC).
+    return strip_trailing_commas_outside_strings("".join(out))
+
+
+def strip_trailing_commas_outside_strings(text: str) -> str:
+    """Remove JSONC trailing commas without touching string contents."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    string_quote = ""
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == string_quote:
+                in_string = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_string = True
+            string_quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == ",":
+            j = i + 1
+            while j < n and text[j].isspace():
+                j += 1
+            if j < n and text[j] in "}]":
+                i += 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"$schema": SCHEMA_URL, "schemaVersion": 1}
+    raw = path.read_text()
+    try:
+        return json.loads(strip_jsonc(raw))
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"error: {path} is not valid JSONC: {e}")
+
+
+def atomic_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False, suffix=".tmp"
+    ) as tmp:
+        tmp.write(encoded)
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, path)
+
+
+def split_path(dotted: str) -> list[str]:
+    if not dotted:
+        raise SystemExit("error: empty key path")
+    parts = dotted.split(".")
+    if any(part == "" for part in parts):
+        raise SystemExit("error: empty key path segment")
+    return parts
+
+
+def get_at(data: Any, parts: list[str]) -> Any:
+    cur = data
+    for p in parts:
+        if not isinstance(cur, dict) or p not in cur:
+            raise SystemExit(f"error: path not present: {'.'.join(parts)}")
+        cur = cur[p]
+    return cur
+
+
+def set_at(data: dict[str, Any], parts: list[str], value: Any) -> bool:
+    cur = data
+    for p in parts[:-1]:
+        if p not in cur:
+            cur[p] = {}
+        elif not isinstance(cur[p], dict):
+            raise SystemExit(
+                f"error: intermediate key '{p}' is not an object "
+                f"(got {type(cur[p]).__name__}); cannot set nested path"
+            )
+        cur = cur[p]
+    leaf = parts[-1]
+    changed = (leaf not in cur) or cur[leaf] != value
+    cur[leaf] = value
+    return changed
+
+
+def unset_at(data: dict[str, Any], parts: list[str]) -> bool:
+    trail: list[tuple[dict[str, Any], str]] = []
+    cur: Any = data
+    for p in parts[:-1]:
+        if not isinstance(cur, dict) or p not in cur:
+            return False
+        trail.append((cur, p))
+        cur = cur[p]
+    if not isinstance(cur, dict) or parts[-1] not in cur:
+        return False
+    del cur[parts[-1]]
+    # Drop now-empty ancestor objects so the file stays tidy.
+    for parent, key in reversed(trail):
+        if isinstance(parent[key], dict) and not parent[key]:
+            del parent[key]
+        else:
+            break
+    return True
+
+
+def parse_value(raw: str) -> Any:
+    """Try JSON first; if it fails, fall back to a plain string."""
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def flatten(prefix: str, value: Any) -> list[str]:
+    if isinstance(value, dict):
+        out: list[str] = []
+        for k, v in value.items():
+            child = f"{prefix}.{k}" if prefix else k
+            out.extend(flatten(child, v))
+        return out
+    return [prefix]
+
+
+def supported_paths_from_source(source: Path) -> list[str]:
+    text = source.read_text()
+    known_sections = (
+        "app.",
+        "terminal.",
+        "notifications.",
+        "sidebar.",
+        "workspaceColors.",
+        "sidebarAppearance.",
+        "automation.",
+        "browser.",
+        "shortcuts.",
+    )
+    candidates = re.findall(r'"([a-zA-Z]+\.[a-zA-Z0-9_.]+)"', text)
+    return sorted({p for p in candidates if p.startswith(known_sections)})
+
+
+def supported_paths_from_reference(skill_root: Path | None) -> list[str]:
+    if skill_root is None:
+        return []
+    reference = skill_root / "references" / "all-keys.md"
+    if not reference.exists():
+        return []
+    text = reference.read_text()
+    return sorted(set(re.findall(r"^\| `([^`]+)` \|", text, re.MULTILINE)))
+
+
+def find_source_file() -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        direct = parent / "Sources" / "CmuxSettingsJSONPathSupport.swift"
+        if direct.exists():
+            return direct
+        hq_checkout = parent / "repo" / "Sources" / "CmuxSettingsJSONPathSupport.swift"
+        if hq_checkout.exists():
+            return hq_checkout
+    return None
+
+
+def find_skill_root() -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if parent.name == "cmux-settings" and (parent / "SKILL.md").exists():
+            return parent
+        if (parent / "references" / "all-keys.md").exists():
+            return parent
+    return None
+
+
+def supported_paths() -> list[str]:
+    source = find_source_file()
+    if source is not None:
+        return supported_paths_from_source(source)
+    return supported_paths_from_reference(find_skill_root())
+
+
+def cmd_path(args: argparse.Namespace) -> int:
+    print(args.file)
+    return 0
+
+
+def cmd_dump(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    if args.no_comments:
+        data = load_settings(path)
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        if path.exists():
+            sys.stdout.write(path.read_text())
+        else:
+            print(f"# {path} does not exist", file=sys.stderr)
+            return 1
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    data = load_settings(Path(args.file))
+    value = get_at(data, split_path(args.key))
+    print(json.dumps(value, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_set(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    parts = split_path(args.key)
+    value = parse_value(args.value)
+    changed = set_at(data, parts, value)
+    if not changed:
+        print(f"unchanged: {args.key} = {json.dumps(value)}")
+        return 0
+    atomic_write(path, data)
+    print(f"set: {args.key} = {json.dumps(value)}")
+    return 0
+
+
+def cmd_unset(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    if not unset_at(data, split_path(args.key)):
+        print(f"unchanged: {args.key} (not present)")
+        return 0
+    atomic_write(path, data)
+    print(f"unset: {args.key}")
+    return 0
+
+
+def cmd_list_supported(args: argparse.Namespace) -> int:
+    paths = supported_paths()
+    if not paths:
+        print(
+            "error: could not load the supported-paths list; "
+            "run from a cmux checkout or reinstall the cmux-settings skill",
+            file=sys.stderr,
+        )
+        return 1
+    for p in paths:
+        print(p)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    data = load_settings(path)
+    supported = set(supported_paths())
+    if not supported:
+        print(
+            "warn: could not load schema path list; only checked JSON parses",
+            file=sys.stderr,
+        )
+        print(f"ok: {path} parses")
+        return 0
+    unknown: list[str] = []
+    # Keep this in sync with top-level structural keys in web/data/cmux.schema.json.
+    structural = {
+        "$schema",
+        "schemaVersion",
+        "actions",
+        "ui",
+        "commands",
+        "vault",
+        "newWorkspaceCommand",
+        "surfaceTabBarButtons",
+        "rightSidebar",
+    }
+    for top, value in data.items():
+        if top in structural:
+            continue
+        if not isinstance(value, dict):
+            unknown.append(top)
+            continue
+        for full in flatten(top, value):
+            if full in supported:
+                continue
+            if any(full.startswith(s + ".") for s in supported):
+                continue
+            unknown.append(full)
+    if unknown:
+        print("unknown settings keys:")
+        for u in unknown:
+            print(f"  {u}")
+        return 1
+    print(f"ok: {path} parses and all settings keys are recognized")
+    return 0
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        atomic_write(path, {"$schema": SCHEMA_URL, "schemaVersion": 1})
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    if editor:
+        try:
+            editor_args = shlex.split(editor)
+        except ValueError as e:
+            print(f"error: invalid editor command: {e}", file=sys.stderr)
+            return 1
+        if not editor_args:
+            print("error: editor command is empty", file=sys.stderr)
+            return 1
+        try:
+            return subprocess.call([*editor_args, str(path)])
+        except FileNotFoundError:
+            print(f"error: editor not found: {editor_args[0]}", file=sys.stderr)
+            return 1
+    for app in (["code", "--wait"], ["cursor", "--wait"], ["open", "-e"], ["xdg-open"]):
+        if shutil.which(app[0]):
+            try:
+                return subprocess.call([*app, str(path)])
+            except FileNotFoundError:
+                continue
+    print(
+        "error: no suitable editor found; set $EDITOR or install code, cursor, open, or xdg-open",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--file",
+        default=str(DEFAULT_PATH),
+        help=f"settings file path (default: {DEFAULT_PATH})",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("path").set_defaults(func=cmd_path)
+
+    p_dump = sub.add_parser("dump")
+    p_dump.add_argument("--no-comments", action="store_true")
+    p_dump.set_defaults(func=cmd_dump)
+
+    p_get = sub.add_parser("get")
+    p_get.add_argument("key")
+    p_get.set_defaults(func=cmd_get)
+
+    p_set = sub.add_parser("set")
+    p_set.add_argument("key")
+    p_set.add_argument("value")
+    p_set.set_defaults(func=cmd_set)
+
+    p_unset = sub.add_parser("unset")
+    p_unset.add_argument("key")
+    p_unset.set_defaults(func=cmd_unset)
+
+    sub.add_parser("list-supported").set_defaults(func=cmd_list_supported)
+    sub.add_parser("validate").set_defaults(func=cmd_validate)
+    sub.add_parser("open").set_defaults(func=cmd_open)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/cmux-shared-behavior/SKILL.md
+++ b/.agents/skills/cmux-shared-behavior/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cmux-shared-behavior
+description: "Shared behavior and mutation-path rules for cmux. Use when a behavior is exposed through multiple entrypoints such as keyboard shortcuts, command palette, context menu, CLI, settings, debug menu, optimistic UI, or tests that previously missed a bug."
+---
+
+# cmux Shared Behavior
+
+Use one shared action/model path when behavior is exposed through multiple entrypoints.
+
+## Shared entrypoints
+
+When a behavior is exposed through multiple surfaces, implement one shared action/model path and verify every entrypoint that should invoke it.
+
+Common entrypoints include:
+
+- keyboard shortcut
+- command palette
+- context menu
+- CLI/socket command
+- settings UI
+- debug menu
+
+Do not patch one surface while leaving the others with duplicated logic.
+
+## Optimistic updates
+
+For optimistic UI or CLI updates:
+
+- keep one mutation path
+- record pending state with a request id or previous snapshot
+- reconcile from the authoritative result
+- handle failure with an explicit rollback or error state
+
+Do not let each entrypoint maintain its own optimistic copy.
+
+## Missed-bug coverage
+
+When a user says tests missed a bug, add or adjust behavior-level coverage around the exact repro path before claiming the fix is complete.

--- a/.agents/skills/cmux-shared-behavior/agents/openai.yaml
+++ b/.agents/skills/cmux-shared-behavior/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Shared Behavior"
+  short_description: "Keep multi-entrypoint behavior and optimistic updates on one shared path."
+  default_prompt: "Use this skill when changing behavior exposed through multiple cmux entrypoints, optimistic UI or CLI mutation flows, or tests that previously missed a user-visible bug."

--- a/.agents/skills/cmux-socket-policy/SKILL.md
+++ b/.agents/skills/cmux-socket-policy/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: cmux-socket-policy
+description: "Socket command threading and focus policy for cmux CLI/socket work. Use when adding or changing socket commands, CLI commands, telemetry commands, focus/select/open/close/send-key behavior, or automation that could steal app focus."
+---
+
+# cmux Socket Policy
+
+## Threading policy
+
+- Do not use `DispatchQueue.main.sync` for high-frequency socket telemetry commands such as `report_*`, `ports_kick`, status/progress updates, or log metadata updates.
+- For telemetry hot paths, parse and validate arguments off-main.
+- Dedupe and coalesce off-main first.
+- Schedule minimal UI/model mutation with `DispatchQueue.main.async` only when needed.
+- Commands that directly manipulate AppKit/Ghostty UI state are allowed to run on the main actor.
+- If adding a new socket command, default to off-main handling and require an explicit reason in code comments when main-thread execution is necessary.
+
+## Focus policy
+
+- Socket/CLI commands must not steal macOS app focus.
+- Do not activate the app or raise windows unless the command has explicit focus intent.
+- Only explicit focus-intent commands may mutate in-app focus/selection.
+- Explicit focus-intent commands include `window.focus`, `workspace.select/next/previous/last`, `surface.focus`, `pane.focus/last`, browser focus commands, and v1 focus equivalents.
+- All non-focus commands should preserve the current user focus context while still applying data/model changes.
+
+## Detailed reference
+
+- Read [references/threading-and-focus.md](references/threading-and-focus.md) when adding a command, changing command execution context, or deciding whether focus changes are allowed.

--- a/.agents/skills/cmux-socket-policy/agents/openai.yaml
+++ b/.agents/skills/cmux-socket-policy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Socket Policy"
+  short_description: "Keep cmux socket commands off hot main-thread paths and focus-safe."
+  default_prompt: "Use this skill when adding or changing cmux socket or CLI commands, telemetry handlers, focus/select/open/close/send-key behavior, or automation that could activate the app or steal focus."

--- a/.agents/skills/cmux-socket-policy/references/threading-and-focus.md
+++ b/.agents/skills/cmux-socket-policy/references/threading-and-focus.md
@@ -1,0 +1,60 @@
+# Socket Threading and Focus
+
+Socket commands are a control plane. They often run because an agent, script, or background tool is reporting state, not because a user asked the app to become active.
+
+## Telemetry hot paths
+
+High-frequency telemetry commands include:
+
+- `report_*`
+- `ports_kick`
+- status updates
+- progress updates
+- log metadata updates
+
+These should avoid synchronous main-thread work. Parse and validate arguments off-main, dedupe/coalesce before crossing to UI state, and schedule only the smallest required mutation.
+
+`DispatchQueue.main.sync` is especially risky because it can block the socket handling path behind UI work and can deadlock if the command path is already main-adjacent.
+
+## Commands allowed on main actor
+
+Commands that directly manipulate AppKit or Ghostty UI state may need main actor execution:
+
+- focus
+- select
+- open/close UI surfaces
+- send key/input
+- list/current queries requiring an exact synchronous UI snapshot
+
+The command should document why main-thread execution is necessary. Do not cargo-cult main actor isolation onto telemetry commands.
+
+## Focus preservation
+
+Most socket commands should not change the user's macOS focus. A background agent may be running in one workspace while the user is actively using another app or cmux workspace.
+
+Non-focus commands should apply model/data changes without:
+
+- activating the app
+- raising a window
+- selecting another workspace
+- focusing a pane
+- focusing a surface
+
+If a command needs focus behavior, name and document it as focus-intent.
+
+## Explicit focus-intent commands
+
+Only explicit focus-intent commands may mutate in-app focus/selection. Examples:
+
+- `window.focus`
+- `workspace.select`
+- `workspace.next`
+- `workspace.previous`
+- `workspace.last`
+- `surface.focus`
+- `pane.focus`
+- `pane.last`
+- browser focus commands
+- v1 focus equivalents
+
+When adding a new command, decide whether it is focus-intent as part of the API contract, not as an implementation accident.

--- a/.agents/skills/cmux-testing/SKILL.md
+++ b/.agents/skills/cmux-testing/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: cmux-testing
+description: "cmux testing rules for Swift Testing, test target compilation, and package/refactor validation. Use when adding or changing tests, touching package/refactor code, or deciding whether reload.sh is enough validation."
+---
+
+# cmux Testing
+
+## Regression test commit policy
+
+When adding a regression test for a bug fix, use a two-commit structure so CI proves the test catches the bug:
+
+1. **Commit 1:** Add the failing test only (no fix). CI should go red.
+2. **Commit 2:** Add the fix. CI should go green.
+
+This makes it visible in the GitHub PR UI that the test genuinely fails without the fix.
+
+## Test quality policy
+
+- Do not add tests that only verify source code text, method signatures, AST fragments, or grep-style patterns.
+- Do not add tests that read checked-in metadata or project files such as `Resources/Info.plist`, `project.pbxproj`, `.xcconfig`, or source files only to assert that a key, string, plist entry, or snippet exists.
+- Tests must verify observable runtime behavior through executable paths (unit/integration/e2e/CLI), not implementation shape.
+- For metadata changes, prefer verifying the built app bundle or the runtime behavior that depends on that metadata, not the checked-in source file.
+- If a behavior cannot be exercised end-to-end yet, add a small runtime seam or harness first, then test through that seam.
+- If no meaningful behavioral or artifact-level test is practical, skip the fake regression test and state that explicitly.
+
+## Test framework
+
+Swift Testing is the current Apple-supported primitive for tests on this codebase (shipped with Swift 6 / Xcode 16, supported on the macOS versions we target). Use it for everything that is not a UI test.
+
+- **Default to Swift Testing for all unit and integration tests.** `import Testing`, annotate tests with `@Test`, group with `@Suite`, assert with `#expect(...)` and `try #require(...)`. Do not write new tests with `import XCTest` unless they are UI tests.
+- **UI tests stay on XCTest / XCUITest.** Swift Testing does not support UI testing (no `XCUIApplication` integration). Files under `cmuxUITests/` continue to use `XCTestCase` + `XCUIApplication`. Do not migrate them and do not try to bridge Swift Testing into UI tests.
+- **New test targets start on Swift Testing.** Every new Swift package's `Tests/<Name>Tests/` directory (e.g. `Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/`) should ship with Swift Testing from the first commit. Xcode 16 auto-detects the framework based on the `import Testing` statement; no extra `Package.swift` configuration is required.
+- **Migration guide when touching an existing XCTest test.** Convert in place: `XCTestCase` subclass becomes a `@Suite struct` (or `final class` if you need a reference type); each `func testFoo()` becomes `@Test func foo()`; `XCTAssertEqual(a, b)` becomes `#expect(a == b)`; `XCTAssertTrue(cond)` becomes `#expect(cond)`; `XCTUnwrap(x)` becomes `try #require(x)`; `XCTFail("msg")` becomes `Issue.record("msg")`. `setUp()` becomes `init()` on the suite; `tearDown()` becomes `deinit`. Async setup is `async init()`. Do not bulk-rewrite untouched tests; migrate incrementally as a side effect of editing the file.
+- **Parameterized tests** use `@Test(arguments: [...])`. Prefer this over duplicate test methods.
+- **Parallelization and shared state.** Swift Testing runs tests in parallel by default, including across suites. If a suite genuinely needs ordering or guards shared mutable state, annotate it with `.serialized` instead of adding locks or sleeps.
+- **Tags** with `@Test(.tags(.something))` (or on a `@Suite`) let CI and local runs filter selectively.
+
+## Test target validation
+
+`reload.sh` does not compile the test target. It builds only the `cmux` scheme, so a green `reload.sh` says nothing about whether `cmuxTests`/`cmuxUITests` still compile. A symbol that is moved or renamed can keep the `cmux` app building while breaking the test target (real case: a `write(to:atomically:)` typo and a removed `TabManager.CommandResult` only surfaced in the `tests` job). Before pushing package/refactor changes, build the `cmux-unit` scheme (with `-derivedDataPath /tmp/cmux-<tag>` and, for `cmuxApp`/`AppDelegate` churn, the GlobalISel workaround flag) or let the `tests` CI job gate it — never treat `reload.sh` alone as proof the tests build.
+
+## Detailed references
+
+- Read [references/swift-testing-migration.md](references/swift-testing-migration.md) when converting XCTest unit tests to Swift Testing or adding new package tests.
+- Read [references/regression-and-quality.md](references/regression-and-quality.md) when adding a regression test, deciding whether a test is behavioral enough, or checking Xcode project test wiring.
+- Read [references/local-vs-ci-validation.md](references/local-vs-ci-validation.md) when choosing between `reload.sh`, `cmux-unit`, GitHub Actions, E2E/UI tests, and Python socket tests.

--- a/.agents/skills/cmux-testing/agents/openai.yaml
+++ b/.agents/skills/cmux-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Testing"
+  short_description: "Use Swift Testing and validate cmux test targets correctly."
+  default_prompt: "Use this skill when adding or changing tests, touching package or refactor code that can break test targets, or deciding whether reload.sh is enough validation."

--- a/.agents/skills/cmux-testing/references/local-vs-ci-validation.md
+++ b/.agents/skills/cmux-testing/references/local-vs-ci-validation.md
@@ -1,0 +1,46 @@
+# Local vs CI Validation
+
+## `reload.sh`
+
+`reload.sh` builds the Debug app for a tag. It does not compile the test target.
+
+A successful reload proves the app target built. It does not prove:
+
+- `cmuxTests` compile
+- `cmuxUITests` compile
+- package test targets compile
+- test-only imports still resolve
+
+For package/refactor work, treat reload as insufficient by itself.
+
+## Unit test target
+
+`xcodebuild -scheme cmux-unit` is safe because it does not launch the app. Prefer CI when practical, but use `cmux-unit` when package/refactor changes can break tests while the app target still builds.
+
+Use a tagged derived data path:
+
+```bash
+xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-<tag> build
+```
+
+For `cmuxApp` or `AppDelegate` churn, include the repo's known GlobalISel workaround flag if required by current project instructions.
+
+## E2E and UI tests
+
+E2E and UI tests run via GitHub Actions or on the VM. Trigger E2E/UI through:
+
+```bash
+gh workflow run test-e2e.yml
+```
+
+Do not launch an untagged app locally to satisfy socket/UI tests.
+
+## Python socket tests
+
+Python socket tests under `tests_v2/` connect to a running cmux instance socket. If they must be run locally, use a tagged build socket:
+
+```bash
+CMUX_SOCKET_PATH=/tmp/cmux-debug-<tag>.sock
+```
+
+Never launch or target an untagged `cmux DEV.app` for these tests. It can conflict with the user's running debug instance.

--- a/.agents/skills/cmux-testing/references/regression-and-quality.md
+++ b/.agents/skills/cmux-testing/references/regression-and-quality.md
@@ -1,0 +1,50 @@
+# Regression and Test Quality
+
+## Regression commit policy
+
+When adding a regression test for a bug fix, use a two-commit structure so CI proves the test catches the bug:
+
+1. Add the failing test only.
+2. Add the fix.
+
+This makes it visible in GitHub that the test fails without the fix and passes with it.
+
+## Behavioral tests
+
+Tests should verify observable runtime behavior through executable paths:
+
+- unit
+- integration
+- E2E
+- CLI
+- artifact-level behavior of a built product
+
+Avoid tests that only verify:
+
+- source code text
+- method signatures
+- AST fragments
+- grep-style patterns
+- checked-in plist/project/config snippets
+
+For metadata changes, prefer testing the built app bundle or the runtime behavior that depends on the metadata. If no meaningful behavioral or artifact-level test is practical, skip the fake regression test and say so.
+
+## Test wiring
+
+Test files in `cmuxTests/` must be wired into `cmux.xcodeproj/project.pbxproj`.
+
+A `.swift` file added to `cmuxTests/` without matching project entries can be silently ignored by Xcode. Both targeted `xcodebuild test -only-testing:cmuxTests/<TestClass>` and bot reviews can pass with "Executed 0 tests".
+
+The `workflow-guard-tests` job runs:
+
+```bash
+./scripts/lint-pbxproj-test-wiring.sh
+```
+
+When hand-editing wiring, use a wired sibling like `TabManagerUnitTests.swift` as the template.
+
+## When tests missed a bug
+
+When the user says tests missed a bug, add or adjust behavior-level coverage around the exact repro path before claiming the fix is complete.
+
+Do not add a broad implementation-shape test that would have passed while the user-visible bug remained.

--- a/.agents/skills/cmux-testing/references/swift-testing-migration.md
+++ b/.agents/skills/cmux-testing/references/swift-testing-migration.md
@@ -1,0 +1,70 @@
+# Swift Testing Migration
+
+Use Swift Testing for unit and integration tests. XCTest remains for UI tests.
+
+## New tests
+
+New unit and integration tests should:
+
+```swift
+import Testing
+
+@Suite
+struct ExampleTests {
+    @Test
+    func computesValue() {
+        #expect(1 + 1 == 2)
+    }
+}
+```
+
+Use `try #require(...)` when a value must be unwrapped before continuing.
+
+## XCTest conversion
+
+When touching an existing XCTest unit test, convert in place if the edit naturally crosses that code.
+
+Mapping:
+
+- `XCTestCase` subclass -> `@Suite struct` or `@Suite final class`
+- `func testFoo()` -> `@Test func foo()`
+- `XCTAssertEqual(a, b)` -> `#expect(a == b)`
+- `XCTAssertTrue(condition)` -> `#expect(condition)`
+- `XCTUnwrap(value)` -> `try #require(value)`
+- `XCTFail("message")` -> `Issue.record("message")`
+- `setUp()` -> `init()`
+- `tearDown()` -> `deinit`
+- async setup -> `async init()`
+
+Do not bulk-rewrite untouched tests just to migrate them.
+
+## Parameterized tests
+
+Prefer:
+
+```swift
+@Test(arguments: [
+    ("input-a", "output-a"),
+    ("input-b", "output-b"),
+])
+func formats(input: String, expected: String) {
+    #expect(format(input) == expected)
+}
+```
+
+This is clearer than duplicating test methods with copy/paste assertions.
+
+## Parallel execution
+
+Swift Testing runs tests in parallel by default, including across suites. If a suite genuinely needs ordering or guards shared mutable state, use `.serialized`:
+
+```swift
+@Suite(.serialized)
+struct FileBackedTests { ... }
+```
+
+Prefer isolated temp directories and injected dependencies over serialization when practical.
+
+## UI tests
+
+Files under `cmuxUITests/` stay on XCTest/XCUITest. Swift Testing does not support `XCUIApplication` UI testing.

--- a/.agents/skills/cmux-workspace/SKILL.md
+++ b/.agents/skills/cmux-workspace/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: cmux-workspace
+description: "Work inside the current cmux workspace and terminal. Use for cmux workspace, current workspace, caller surface, panes, surfaces, socket targeting, and non-interfering cmux automation."
+---
+
+# cmux Workspace
+
+Use this skill when a task should be scoped to the cmux workspace that invoked the agent. A workspace is the sidebar tab-like unit in cmux. It contains split panes, and each pane contains one or more surfaces. A surface is the terminal or browser session the user interacts with.
+
+## Default Rule
+
+Scope actions to the current caller workspace unless the user explicitly asks for another workspace, another window, or global state.
+
+Do not assume the visually focused cmux workspace is the right target. An agent can be running in one workspace while the user is looking at another. Prefer the caller environment first:
+
+```bash
+printf 'workspace=%s\nsurface=%s\nsocket=%s\n' \
+  "${CMUX_WORKSPACE_ID:-}" \
+  "${CMUX_SURFACE_ID:-}" \
+  "${CMUX_SOCKET_PATH:-}"
+cmux identify --json
+```
+
+Use `CMUX_WORKSPACE_ID` as the default workspace anchor and `CMUX_SURFACE_ID` as the default caller terminal/surface anchor. If those are missing, use `cmux identify --json` and be explicit that you are using the currently focused cmux context.
+
+## Non-Disruptive Automation
+
+The user may be visually focused on a different workspace, window, or app while an agent works in the caller workspace. Treat layout and focus as separate concerns. Never call focus-changing verbs speculatively.
+
+Never call these without an explicit user ask:
+
+- `select-workspace` switches the visible sidebar tab.
+- `focus-pane` / `focus-panel` yanks pane or surface focus.
+- `tab-action` with focus-changing actions.
+
+These are user-affecting actions, like clicks. The rule applies even inside the caller's own workspace, since the user may be looking elsewhere.
+
+Build layout additively, in one shot. Prefer commands that create a new pane already populated with the right surface:
+
+```bash
+# pane and content in one call, no follow-up needed
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID}" --type browser --direction right --url "http://127.0.0.1:8765"
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID}" --type terminal --direction down
+```
+
+Avoid create-then-move-then-focus chains. If a layout command rejects a valid `surface:` or `pane:` ref, do not work around it by focusing. Report the bug to the user and stop.
+
+Pass `--focus false` whenever the verb supports it. `move-surface --focus false` preserves the user's current attention. Other commands may grow the same flag over time (https://github.com/manaflow-ai/cmux/issues/1418, https://github.com/manaflow-ai/cmux/issues/2820).
+
+## Right-Side Helper Pane
+
+When opening auxiliary output for the current task (preview apps, TUIs, logs, one-off shells, browser checks), keep the workspace organized by reusing a helper pane to the right of the caller terminal.
+
+First inspect the caller context and panes:
+
+```bash
+cmux identify --json
+cmux list-panes --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-pane-surfaces --workspace "${CMUX_WORKSPACE_ID:-}" --json
+```
+
+Use this policy:
+
+- If the caller workspace already has a non-caller helper pane, add a new surface to that pane instead of creating another pane:
+  ```bash
+  cmux new-surface --workspace "${CMUX_WORKSPACE_ID:-}" --pane pane:<helper> --type terminal --focus false
+  ```
+- If there is no helper pane, create exactly one right-side pane:
+  ```bash
+  cmux new-pane --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal --direction right --focus false
+  ```
+- If there are multiple obvious stale helper panes from this same automation and the user asked to tidy or reuse, keep one right helper pane and clean up the duplicates. Do not close panes you cannot confidently identify as stale helper output.
+- Send commands to the new or reused helper surface by explicit surface ref. Do not focus it unless the user asks.
+
+This means repeated "open it" requests should normally create tabs inside the existing right helper pane, not more splits.
+
+## Hierarchy
+
+- Window: a macOS cmux window.
+- Workspace: a sidebar entry. The UI may call it a tab, but CLI/socket APIs call it a workspace.
+- Pane: a split region inside a workspace.
+- Surface: a tab inside a pane. Surfaces can be terminals or browser panels.
+- Panel: internal content type inside a surface. Prefer CLI surface commands instead of panel internals.
+
+## Inspect Current Context
+
+```bash
+cmux identify --json
+cmux current-workspace --json
+cmux list-workspaces --json
+cmux list-panes --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-pane-surfaces --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux list-panels --workspace "${CMUX_WORKSPACE_ID:-}" --json
+```
+
+Use `--id-format both` when logs or handoffs need stable UUIDs plus human refs:
+
+```bash
+cmux --json --id-format both identify
+```
+
+## Workspace-Scoped Actions
+
+Prefer explicit workspace flags even when env vars are set. It makes automation auditable and avoids affecting a focused workspace in another window.
+
+```bash
+# create a new workspace when the user asks for a new task area
+cmux new-workspace --name "debug auth" --cwd "$PWD"
+
+# rename / close (only when explicitly requested)
+cmux rename-workspace --workspace "${CMUX_WORKSPACE_ID:-}" -- "build fix"
+cmux close-workspace --workspace workspace:4
+cmux close-surface --workspace "${CMUX_WORKSPACE_ID:-}" --surface surface:3
+
+# additive layout (safe, no focus side effects beyond the command's own defaults)
+cmux new-pane --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal --direction right
+cmux new-surface --workspace "${CMUX_WORKSPACE_ID:-}" --type terminal
+
+# focus-changing (USER-AFFECTING, only on explicit ask, see Non-Disruptive Automation above)
+cmux select-workspace --workspace workspace:2
+cmux focus-pane --workspace "${CMUX_WORKSPACE_ID:-}" --pane pane:2
+cmux focus-panel --workspace "${CMUX_WORKSPACE_ID:-}" --panel surface:3
+```
+
+## Caller Terminal
+
+The current terminal is the surface that invoked the agent. Treat it as the safest anchor for relative operations.
+
+```bash
+# send to the focused terminal in the caller workspace
+cmux send "npm test\n"
+
+# send to the exact caller surface
+cmux send --surface "${CMUX_SURFACE_ID:-}" "git status\n"
+cmux send-key --surface "${CMUX_SURFACE_ID:-}" enter
+```
+
+Do not send keystrokes, close surfaces, or change focus in other workspaces unless the user asked for that target.
+
+## Moving Surfaces
+
+Reorder a surface within its pane:
+
+```bash
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --before surface:3
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --after surface:3
+cmux move-surface --surface "${CMUX_SURFACE_ID}" --index 0
+```
+
+Move a surface to another existing pane. Pass `--focus false` to keep the user's current attention put:
+
+```bash
+cmux move-surface --surface surface:240 --pane pane:172 --focus false
+```
+
+Split a surface off into a new pane:
+
+```bash
+cmux drag-surface-to-split --surface surface:240 down
+```
+
+Known papercut: `drag-surface-to-split` currently routes through V1 and resolves the workspace via UI focus, so it can fail with `ERROR: Surface not found` when the caller's workspace is not the visually focused one. Tracked at https://github.com/manaflow-ai/cmux/issues/1901, related to https://github.com/manaflow-ai/cmux/issues/3189. Until that lands, prefer building the layout additively (see Non-Disruptive Automation above) over create-then-split.
+
+Do not call `focus-pane` or `focus-panel` to recover from a failed move. Report the failure and stop.
+
+## Sidebar State
+
+Status, progress, and logs should usually be attached to the current workspace so the sidebar reflects this task.
+
+```bash
+cmux set-status build "running" --workspace "${CMUX_WORKSPACE_ID:-}" --color "#ff9500"
+cmux set-progress 0.4 --label "Building" --workspace "${CMUX_WORKSPACE_ID:-}"
+cmux log --workspace "${CMUX_WORKSPACE_ID:-}" --level info -- "Started build"
+cmux sidebar-state --workspace "${CMUX_WORKSPACE_ID:-}" --json
+cmux clear-status build --workspace "${CMUX_WORKSPACE_ID:-}"
+cmux clear-progress --workspace "${CMUX_WORKSPACE_ID:-}"
+```
+
+## Contributor Reloads
+
+For cmux app/runtime changes in a cmux source checkout, use tagged reloads from the active worktree. A tagged reload creates an isolated app name, bundle ID, debug socket, and DerivedData path.
+
+```bash
+./scripts/reload.sh --tag <short-tag>
+```
+
+Never build or launch untagged `cmux DEV`. If tests or tools need a socket, use the tag-specific socket:
+
+```bash
+CMUX_SOCKET_PATH=/tmp/cmux-debug-<short-tag>.sock cmux identify --json
+```
+
+## Socket and Access
+
+Use the socket path provided by cmux before falling back to defaults:
+
+```bash
+SOCK="${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+```
+
+Socket access can be off, restricted to cmux-spawned processes, or allow all local processes. If a command cannot connect, inspect capabilities before changing settings:
+
+```bash
+cmux capabilities --json
+cmux ping
+```
+
+## References
+
+- [references/commands.md](references/commands.md) enumerates workspace, pane, surface, notification, and utility commands.
+- [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) covers browser surfaces with the same current-workspace rule.
+
+## Rules
+
+- Work in the current caller workspace by default.
+- Use `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, and `CMUX_SOCKET_PATH` before focused-window fallbacks.
+- Prefer explicit `--workspace` and `--surface` flags for mutating actions.
+- Never call `focus-pane`, `focus-panel`, `select-workspace`, or focus-changing `tab-action` verbs unless the user explicitly asked. The user may be visually on a different workspace, window, or app.
+- Pass `--focus false` on `move-surface` and any creation verb that supports it.
+- For auxiliary output, reuse the right-side helper pane; create one only if it does not exist.
+- Build layout additively with `new-pane --type ... --url ...` rather than create-then-move-then-focus chains.
+- If a CLI command rejects a valid surface or pane ref, report it to the user. Do not work around by focusing.
+- Do not close, focus, move, or send input to another workspace unless the user names that target.
+- Use short refs for chat and command examples. Use UUIDs only for logs, persistence, or debugging.
+- For app/runtime changes in a cmux source checkout, reload with `./scripts/reload.sh --tag <tag>` from the worktree before dogfood handoff.

--- a/.agents/skills/cmux-workspace/agents/openai.yaml
+++ b/.agents/skills/cmux-workspace/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Workspace"
+  short_description: "Scope cmux automation to the current workspace, caller terminal, panes, and surfaces."
+  default_prompt: "Use this skill to identify the current cmux caller workspace and surface, then keep workspace, pane, surface, browser, sidebar, and socket actions scoped to that context unless the user explicitly names another target."

--- a/.agents/skills/cmux-workspace/references/commands.md
+++ b/.agents/skills/cmux-workspace/references/commands.md
@@ -1,0 +1,110 @@
+# cmux Workspace Command Reference
+
+Use these commands from a cmux terminal. Most commands infer the caller workspace from `CMUX_WORKSPACE_ID`, but explicit flags are safer for automation.
+
+## Context
+
+```bash
+cmux identify --json
+cmux current-workspace --json
+cmux capabilities --json
+cmux ping
+```
+
+## Windows and Workspaces
+
+```bash
+cmux list-windows
+cmux current-window
+cmux new-window
+cmux focus-window --window window:2
+cmux close-window --window window:2
+
+cmux list-workspaces
+cmux list-workspaces --json
+cmux new-workspace --name "task" --cwd "$PWD"
+cmux new-workspace --command "npm run dev"
+cmux new-workspace --layout '{"root":{"type":"terminal"}}'
+cmux current-workspace
+cmux select-workspace --workspace workspace:2
+cmux rename-workspace --workspace workspace:2 -- "new name"
+cmux close-workspace --workspace workspace:2
+cmux reorder-workspace --workspace workspace:4 --before workspace:2
+cmux move-workspace-to-window --workspace workspace:4 --window window:1
+```
+
+## Panes and Surfaces
+
+```bash
+cmux list-panes --workspace "$CMUX_WORKSPACE_ID"
+cmux list-pane-surfaces --workspace "$CMUX_WORKSPACE_ID" --pane pane:1
+cmux list-panels --workspace "$CMUX_WORKSPACE_ID"
+cmux tree --workspace "$CMUX_WORKSPACE_ID"
+
+cmux new-split right --workspace "$CMUX_WORKSPACE_ID"
+cmux new-split down --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID"
+cmux new-pane --workspace "$CMUX_WORKSPACE_ID" --type terminal --direction right
+cmux new-pane --workspace "$CMUX_WORKSPACE_ID" --type browser --url http://localhost:3000
+cmux new-surface --workspace "$CMUX_WORKSPACE_ID" --type terminal --pane pane:1
+cmux new-surface --workspace "$CMUX_WORKSPACE_ID" --type browser --pane pane:1 --url http://localhost:3000
+
+cmux focus-pane --workspace "$CMUX_WORKSPACE_ID" --pane pane:2
+cmux focus-panel --workspace "$CMUX_WORKSPACE_ID" --panel surface:3
+cmux close-surface --workspace "$CMUX_WORKSPACE_ID" --surface surface:3
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux reorder-surface --surface surface:7 --before surface:3
+cmux move-tab-to-new-workspace --surface surface:7 --title "browser"
+```
+
+## Input
+
+```bash
+cmux send "echo hello\n"
+cmux send-key enter
+cmux send --surface "$CMUX_SURFACE_ID" "git status\n"
+cmux send-key --surface "$CMUX_SURFACE_ID" enter
+cmux read-screen --surface "$CMUX_SURFACE_ID"
+```
+
+## Sidebar Metadata
+
+```bash
+cmux set-status build "running" --workspace "$CMUX_WORKSPACE_ID" --icon hammer --color "#ff9500"
+cmux clear-status build --workspace "$CMUX_WORKSPACE_ID"
+cmux list-status --workspace "$CMUX_WORKSPACE_ID"
+cmux set-progress 0.5 --workspace "$CMUX_WORKSPACE_ID" --label "Building"
+cmux clear-progress --workspace "$CMUX_WORKSPACE_ID"
+cmux log --workspace "$CMUX_WORKSPACE_ID" --level info -- "Build started"
+cmux list-log --workspace "$CMUX_WORKSPACE_ID" --limit 20
+cmux clear-log --workspace "$CMUX_WORKSPACE_ID"
+cmux sidebar-state --workspace "$CMUX_WORKSPACE_ID" --json
+```
+
+## Notifications and Attention
+
+```bash
+cmux notify --title "Done" --body "Task complete"
+cmux list-notifications --json
+cmux clear-notifications
+cmux trigger-flash --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID"
+cmux surface-health --workspace "$CMUX_WORKSPACE_ID" --json
+```
+
+## Config and Docs
+
+```bash
+cmux docs api
+cmux docs browser
+cmux docs settings
+cmux settings path
+cmux settings cmux-json
+cmux settings shortcuts
+cmux reload-config
+```
+
+## Tagged Reloads
+
+```bash
+./scripts/reload.sh --tag <short-tag>
+CMUX_SOCKET_PATH=/tmp/cmux-debug-<short-tag>.sock cmux identify --json
+```

--- a/.agents/skills/cmux/SKILL.md
+++ b/.agents/skills/cmux/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cmux
+description: End-user control of cmux topology and routing (windows, workspaces, panes/surfaces, focus, moves, reorder, identify, trigger flash). Use when automation needs deterministic placement and navigation in a multi-pane cmux layout.
+---
+
+# cmux Core Control
+
+Use this skill to control non-browser cmux topology and routing.
+
+## Core Concepts
+
+- Window: top-level macOS cmux window.
+- Workspace: tab-like group within a window.
+- Pane: split container in a workspace.
+- Surface: a tab within a pane (terminal or browser panel).
+
+## Fast Start
+
+```bash
+# identify current caller context
+cmux identify --json
+
+# list topology
+cmux list-windows
+cmux list-workspaces
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+
+# create/focus/move
+cmux new-workspace
+cmux new-split right --panel pane:1
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+
+# attention cue
+cmux trigger-flash --surface surface:7
+```
+
+## Settings and Docs
+
+Use `cmux docs settings` before changing cmux-owned settings. It prints the docs URL, schema URL, raw GitHub resources, cmux.json paths, and reload command.
+
+```bash
+cmux docs settings
+cmux settings path
+```
+
+cmux-owned settings live in `~/.config/cmux/cmux.json`. Legacy `~/.config/cmux/settings.json` and `~/Library/Application Support/com.cmuxterm.app/settings.json` files are read only as fallback for missing keys. Before editing, copy any existing `cmux.json` file to a timestamped `.bak` next to it so the user can revert. Edit the user file, then reload:
+
+```bash
+cmux reload-config
+```
+
+`cmux reload-config` reloads BOTH `cmux.json` and Ghostty config (`~/.config/ghostty/config`) and refreshes terminals in place. No app restart needed.
+
+Use cmux settings for app behavior, sidebar, notifications, browser behavior, automation, workspace colors, and cmux-owned shortcuts. Terminal rendering settings such as font, cursor style, theme, scrollback, background transparency (`background-opacity`), and blur (`background-blur`) belong in Ghostty config at `~/.config/ghostty/config`.
+
+Open the UI when useful:
+
+```bash
+cmux settings
+cmux settings cmux-json
+cmux settings shortcuts
+```
+
+## Handle Model
+
+- Default output uses short refs: `window:N`, `workspace:N`, `pane:N`, `surface:N`.
+- UUIDs are still accepted as inputs.
+- Request UUID output only when needed: `--id-format uuids|both`.
+
+## Deep-Dive References
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/handles-and-identify.md](references/handles-and-identify.md) | Handle syntax, self-identify, caller targeting |
+| [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle and reorder/move |
+| [references/panes-surfaces.md](references/panes-surfaces.md) | Splits, surfaces, move/reorder, focus routing |
+| [references/trigger-flash-and-health.md](references/trigger-flash-and-health.md) | Flash cue and surface health checks |
+| [../cmux-workspace/SKILL.md](../cmux-workspace/SKILL.md) | Current caller workspace rules and non-disruptive automation |
+| [../cmux-settings/SKILL.md](../cmux-settings/SKILL.md) | Safe cmux.json settings edits and validation |
+| [../cmux-browser/SKILL.md](../cmux-browser/SKILL.md) | Browser automation on surface-backed webviews |
+| [../cmux-markdown/SKILL.md](../cmux-markdown/SKILL.md) | Markdown viewer panel with live file watching |

--- a/.agents/skills/cmux/agents/openai.yaml
+++ b/.agents/skills/cmux/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux Core"
+  short_description: "Control windows/workspaces/panes/surfaces and routing with cmux CLI."
+  default_prompt: "Use this skill to inspect and manipulate cmux topology: identify context, target handles, create/focus/move/reorder windows/workspaces/panes/surfaces, and use trigger-flash for visual confirmation."

--- a/.agents/skills/cmux/references/handles-and-identify.md
+++ b/.agents/skills/cmux/references/handles-and-identify.md
@@ -1,0 +1,35 @@
+# Handles and Identify
+
+Use `identify` and short handles for deterministic automation targeting.
+
+## Handle Inputs
+
+Most v2-backed commands accept:
+- UUID
+- short ref (`window:N`, `workspace:N`, `pane:N`, `surface:N`)
+- index (where legacy/index-based commands still allow it)
+
+## Self Identify
+
+```bash
+cmux identify --json
+```
+
+Returns current focused topology plus optional caller resolution.
+
+## Caller Override
+
+```bash
+cmux identify --workspace workspace:2
+cmux identify --workspace workspace:2 --surface surface:8
+```
+
+Useful for agents that need to route relative actions from a known caller anchor.
+
+## Output Shaping
+
+```bash
+cmux --json identify                 # refs-first output
+cmux --json --id-format both identify
+cmux --json --id-format uuids identify
+```

--- a/.agents/skills/cmux/references/panes-surfaces.md
+++ b/.agents/skills/cmux/references/panes-surfaces.md
@@ -1,0 +1,37 @@
+# Panes and Surfaces
+
+Split layout, surface creation, focus, move, and reorder.
+
+## Inspect
+
+```bash
+cmux list-panes
+cmux list-pane-surfaces --pane pane:1
+```
+
+## Create Splits/Surfaces
+
+```bash
+cmux new-split right --panel pane:1
+cmux new-surface --type terminal --pane pane:1
+cmux new-surface --type browser --pane pane:1 --url https://example.com
+```
+
+## Focus and Close
+
+```bash
+cmux focus-pane --pane pane:2
+cmux focus-panel --panel surface:7
+cmux close-surface --surface surface:7
+```
+
+## Move/Reorder Surfaces
+
+```bash
+cmux move-surface --surface surface:7 --pane pane:2 --focus true
+cmux move-surface --surface surface:7 --workspace workspace:2 --window window:1 --after surface:4
+cmux split-off --surface surface:7 right
+cmux reorder-surface --surface surface:7 --before surface:3
+```
+
+Surface identity is stable across move/reorder/split-off operations. Layout commands are focus-neutral by default; pass `--focus true` only when you want the moved or created surface selected.

--- a/.agents/skills/cmux/references/trigger-flash-and-health.md
+++ b/.agents/skills/cmux/references/trigger-flash-and-health.md
@@ -1,0 +1,23 @@
+# Trigger Flash and Surface Health
+
+Operational checks useful in automation loops.
+
+## Trigger Flash
+
+Flash a surface or workspace to provide visual confirmation in UI:
+
+```bash
+cmux trigger-flash --surface surface:7
+cmux trigger-flash --workspace workspace:2
+```
+
+## Surface Health
+
+Use health output to detect hidden/detached/non-windowed surfaces:
+
+```bash
+cmux surface-health
+cmux surface-health --workspace workspace:2
+```
+
+Use this before routing focused input if UI state may be stale.

--- a/.agents/skills/cmux/references/windows-workspaces.md
+++ b/.agents/skills/cmux/references/windows-workspaces.md
@@ -1,0 +1,31 @@
+# Windows and Workspaces
+
+Window/workspace lifecycle and ordering operations.
+
+## Inspect
+
+```bash
+cmux list-windows
+cmux current-window
+cmux list-workspaces
+cmux current-workspace
+```
+
+## Create/Focus/Close
+
+```bash
+cmux new-window
+cmux focus-window --window window:2
+cmux close-window --window window:2
+
+cmux new-workspace
+cmux select-workspace --workspace workspace:4
+cmux close-workspace --workspace workspace:4
+```
+
+## Reorder and Move
+
+```bash
+cmux reorder-workspace --workspace workspace:4 --before workspace:2
+cmux move-workspace-to-window --workspace workspace:4 --window window:1
+```

--- a/claude/skills/cmux
+++ b/claude/skills/cmux
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux

--- a/claude/skills/cmux-architecture
+++ b/claude/skills/cmux-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-architecture

--- a/claude/skills/cmux-backend
+++ b/claude/skills/cmux-backend
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-backend

--- a/claude/skills/cmux-browser
+++ b/claude/skills/cmux-browser
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-browser

--- a/claude/skills/cmux-custom-sidebar
+++ b/claude/skills/cmux-custom-sidebar
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-custom-sidebar

--- a/claude/skills/cmux-customization
+++ b/claude/skills/cmux-customization
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-customization

--- a/claude/skills/cmux-debugging
+++ b/claude/skills/cmux-debugging
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-debugging

--- a/claude/skills/cmux-dev-workflow
+++ b/claude/skills/cmux-dev-workflow
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-dev-workflow

--- a/claude/skills/cmux-diagnostics
+++ b/claude/skills/cmux-diagnostics
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-diagnostics

--- a/claude/skills/cmux-ghostty
+++ b/claude/skills/cmux-ghostty
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-ghostty

--- a/claude/skills/cmux-keyboard-shortcuts
+++ b/claude/skills/cmux-keyboard-shortcuts
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-keyboard-shortcuts

--- a/claude/skills/cmux-localization
+++ b/claude/skills/cmux-localization
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-localization

--- a/claude/skills/cmux-markdown
+++ b/claude/skills/cmux-markdown
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-markdown

--- a/claude/skills/cmux-release
+++ b/claude/skills/cmux-release
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-release

--- a/claude/skills/cmux-settings
+++ b/claude/skills/cmux-settings
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-settings

--- a/claude/skills/cmux-shared-behavior
+++ b/claude/skills/cmux-shared-behavior
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-shared-behavior

--- a/claude/skills/cmux-socket-policy
+++ b/claude/skills/cmux-socket-policy
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-socket-policy

--- a/claude/skills/cmux-testing
+++ b/claude/skills/cmux-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-testing

--- a/claude/skills/cmux-workspace
+++ b/claude/skills/cmux-workspace
@@ -1,0 +1,1 @@
+../../.agents/skills/cmux-workspace

--- a/cmux/cmux.json
+++ b/cmux/cmux.json
@@ -1,0 +1,298 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+  "schemaVersion": 1,
+  "markdown": {
+    "fontFamily": "PlemolJP35 Console NF"
+  },
+  "automation": {
+    "suppressSubagentNotifications": false,
+    "ripgrepBinaryPath": "/Users/roy/.local/share/devbox/global/default/.devbox/nix/profile/default/bin/rg"
+  },
+  "terminal": {
+    "agentHibernation": {
+      "enabled": true,
+      "idleSeconds": 60,
+      "maxLiveTerminals": 12
+    }
+  }
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when ~/.config/cmux/cmux.json is missing.
+  // Legacy settings.json files are read only as fallback for keys not present here.
+  //   "app" : {
+  //     "renameSelectsExistingName" : true,
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "appIcon" : "automatic",
+  //     "forkConversationDefaultDestination" : "right",
+  //     "preferredEditor" : "",
+  //     "language" : "system",
+  //     "focusPaneOnFirstClick" : false,
+  //     "menuBarOnly" : false,
+  //     "windowTitleTemplate" : "",
+  //     "minimalMode" : false,
+  //     "workspaceInheritWorkingDirectory" : true,
+  //     "reorderOnNotification" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "confirmQuit" : "always",
+  //     "hideTabCloseButton" : false,
+  //     "appearance" : "system",
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "openSupportedFilesInCmux" : true,
+  //     "openMarkdownInCmuxViewer" : true,
+  //     "iMessageMode" : false,
+  //     "warnBeforeClosingTab" : true,
+  //     "warnBeforeClosingTabXButton" : false
+  //   },
+  //   "workspaceGroups" : {
+  //     "newWorkspacePlacement" : "afterCurrent"
+  //   },
+  //   "terminal" : {
+  //     "autoResumeAgentSessions" : true,
+  //     "showTextBoxOnNewTerminals" : false,
+  //     "agentHibernation" : {
+  //       "idleSeconds" : 5,
+  //       "maxLiveTerminals" : 12,
+  //       "enabled" : false
+  //     },
+  //     "showScrollBar" : true,
+  //     "textBoxMaxLines" : 10,
+  //     "copyOnSelect" : false,
+  //     "focusTextBoxOnNewTerminals" : false,
+  //     "resumeCommands" : [
+  // 
+  //     ],
+  //     "rendererRealization" : {
+  //       "idleSeconds" : 30,
+  //       "maxWarmRenderers" : 12,
+  //       "enabled" : true
+  //     }
+  //   },
+  //   "notifications" : {
+  //     "dockBadge" : true,
+  //     "showInMenuBar" : true,
+  //     "command" : "",
+  //     "hooks" : [
+  // 
+  //     ],
+  //     "paneFlash" : true,
+  //     "customSoundFilePath" : "",
+  //     "sound" : "default",
+  //     "hooksMode" : "append",
+  //     "unreadPaneRing" : true
+  //   },
+  //   "sidebar" : {
+  //     "showBranchDirectory" : true,
+  //     "branchLayout" : "vertical",
+  //     "hideAllDetails" : false,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "showPorts" : true,
+  //     "showNotificationMessage" : true,
+  //     "stackBranchDirectory" : false,
+  //     "makePullRequestsClickable" : true,
+  //     "watchGitStatus" : true,
+  //     "pathLastSegmentOnly" : false,
+  //     "showSSH" : true,
+  //     "showPullRequests" : true,
+  //     "wrapWorkspaceTitles" : false,
+  //     "showLog" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showWorkspaceDescription" : true,
+  //     "showProgress" : true,
+  //     "showCustomMetadata" : true
+  //   },
+  //   "workspaceColors" : {
+  //     "notificationBadgeColor" : null,
+  //     "colors" : {
+  //       "Navy" : "#1A5276",
+  //       "Orange" : "#A04000",
+  //       "Indigo" : "#283593",
+  //       "Purple" : "#6A1B9A",
+  //       "Amber" : "#7D6608",
+  //       "Rose" : "#880E4F",
+  //       "Magenta" : "#AD1457",
+  //       "Red" : "#C0392B",
+  //       "Aqua" : "#0E6B8C",
+  //       "Green" : "#196F3D",
+  //       "Olive" : "#4A5C18",
+  //       "Blue" : "#1565C0",
+  //       "Brown" : "#7B3F00",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Teal" : "#006B6B",
+  //       "Crimson" : "#922B21"
+  //     },
+  //     "indicatorStyle" : "leftRail",
+  //     "selectionColor" : null
+  //   },
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "tintOpacity" : 0.17999999999999999,
+  //     "tintColor" : "#000000",
+  //     "lightModeTintColor" : null,
+  //     "matchTerminalBackground" : false
+  //   },
+  //   "automation" : {
+  //     "socketPassword" : "",
+  //     "claudeCodeIntegration" : true,
+  //     "kiroIntegration" : true,
+  //     "geminiIntegration" : true,
+  //     "portRange" : 10,
+  //     "ripgrepBinaryPath" : "",
+  //     "ampIntegration" : true,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "portBase" : 9100,
+  //     "claudeBinaryPath" : "",
+  //     "suppressSubagentNotifications" : true,
+  //     "cursorIntegration" : true,
+  //     "kiroNotificationLevel" : "standard"
+  //   },
+  //   "browser" : {
+  //     "defaultSearchEngine" : "google",
+  //     "theme" : "system",
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "*.localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ],
+  //     "discardHiddenWebViews" : true,
+  //     "showSearchSuggestions" : true,
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  // 
+  //     ],
+  //     "showImportHintOnBlankTabs" : true,
+  //     "hiddenWebViewDiscardDelaySeconds" : 300,
+  //     "reactGrabVersion" : "0.1.29",
+  //     "customSearchEngineURLTemplate" : "https:\/\/www.google.com\/search?q={query}",
+  //     "customSearchEngineName" : "",
+  //     "urlsToAlwaysOpenExternally" : [
+  // 
+  //     ]
+  //   },
+  //   "markdown" : {
+  //     "maxWidth" : 980,
+  //     "fontSize" : 15,
+  //     "fontFamily" : ""
+  //   },
+  //   "fileEditor" : {
+  //     "wordWrap" : false
+  //   },
+  //   "fileExplorer" : {
+  //     "doubleClickAction" : "preview"
+  //   },
+  //   "diffViewer" : {
+  //     "defaultLayout" : "unified"
+  //   },
+  //   "shortcuts" : {
+  //     "bindings" : {
+  //       "editWorkspaceDescription" : "cmd+opt+e",
+  //       "browserReload" : "cmd+r",
+  //       "toggleFullScreen" : "cmd+ctrl+f",
+  //       "closeTab" : "cmd+w",
+  //       "toggleSplitZoom" : "cmd+shift+\r",
+  //       "closeWindow" : "cmd+ctrl+w",
+  //       "quit" : "cmd+q",
+  //       "canvasOverview" : "cmd+ctrl+o",
+  //       "toggleCanvasLayout" : "cmd+ctrl+c",
+  //       "canvasZoomReset" : "cmd+opt+0",
+  //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+  //       "canvasRevealFocusedPane" : "cmd+ctrl+r",
+  //       "markdownZoomOut" : "cmd+-",
+  //       "goToWorkspace" : "cmd+p",
+  //       "findNext" : "cmd+g",
+  //       "selectSurfaceByNumber" : "ctrl+1",
+  //       "toggleSidebar" : "cmd+b",
+  //       "findPrevious" : "cmd+opt+g",
+  //       "showHideAllWindows" : "cmd+opt+ctrl+.",
+  //       "splitDown" : "cmd+shift+d",
+  //       "commandPalettePrevious" : "ctrl+p",
+  //       "newWindow" : "cmd+shift+n",
+  //       "browserZoomIn" : "cmd+=",
+  //       "focusRight" : "cmd+opt+→",
+  //       "markdownZoomReset" : "cmd+0",
+  //       "canvasAlignRight" : "",
+  //       "diffViewerScrollDown" : "j",
+  //       "useSelectionForFind" : "cmd+e",
+  //       "browserBack" : "cmd+[",
+  //       "prevSidebarTab" : "cmd+ctrl+[",
+  //       "focusBrowserAddressBar" : "cmd+l",
+  //       "markOldestUnreadAndJumpNext" : "cmd+ctrl+u",
+  //       "focusUp" : "cmd+opt+↑",
+  //       "browserZoomOut" : "cmd+-",
+  //       "toggleTerminalCopyMode" : "cmd+shift+m",
+  //       "attachTextBoxFile" : "cmd+shift+opt+a",
+  //       "focusDown" : "cmd+opt+↓",
+  //       "splitBrowserRight" : "cmd+opt+d",
+  //       "renameTab" : "cmd+r",
+  //       "closeOtherTabsInPane" : "cmd+opt+t",
+  //       "browserForward" : "cmd+]",
+  //       "groupSelectedWorkspaces" : "cmd+shift+g",
+  //       "diffViewerScrollToTop" : [
+  //         "g",
+  //         "g"
+  //       ],
+  //       "focusTextBoxInput" : "cmd+shift+a",
+  //       "toggleUnread" : "cmd+opt+u",
+  //       "focusHistoryForward" : "cmd+]",
+  //       "showNotifications" : "cmd+i",
+  //       "newSurface" : "cmd+t",
+  //       "canvasDistributeHorizontally" : "",
+  //       "canvasZoomOut" : "cmd+opt+-",
+  //       "splitRight" : "cmd+d",
+  //       "commandPaletteNext" : "ctrl+n",
+  //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+  //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+  //       "renameWorkspace" : "cmd+shift+r",
+  //       "reloadConfiguration" : "cmd+shift+,",
+  //       "diffViewerScrollUp" : "k",
+  //       "commandPalette" : "cmd+shift+p",
+  //       "closeWorkspace" : "cmd+shift+w",
+  //       "focusHistoryBack" : "cmd+[",
+  //       "equalizeSplits" : "cmd+ctrl+=",
+  //       "canvasZoomIn" : "cmd+opt+=",
+  //       "splitBrowserDown" : "cmd+shift+opt+d",
+  //       "canvasAlignBottom" : "",
+  //       "hideFind" : "cmd+shift+opt+f",
+  //       "nextSidebarTab" : "cmd+ctrl+]",
+  //       "nextSurface" : "cmd+shift+]",
+  //       "focusRightSidebar" : "cmd+shift+e",
+  //       "diffViewerOpenFileSearch" : "\/",
+  //       "triggerFlash" : "cmd+shift+h",
+  //       "prevSurface" : "cmd+shift+[",
+  //       "openSettings" : "cmd+,",
+  //       "selectWorkspaceByNumber" : "cmd+1",
+  //       "toggleFocusedWorkspaceGroupCollapsed" : "cmd+ctrl+.",
+  //       "focusLeft" : "cmd+opt+←",
+  //       "globalSearch" : "cmd+opt+f",
+  //       "toggleReactGrab" : "cmd+shift+g",
+  //       "newTab" : "cmd+n",
+  //       "canvasTidy" : "cmd+ctrl+t",
+  //       "jumpToUnread" : "cmd+shift+u",
+  //       "openBrowser" : "cmd+shift+l",
+  //       "findInDirectory" : "cmd+shift+f",
+  //       "openDiffViewer" : "cmd+shift+ctrl+d",
+  //       "toggleFileExplorer" : "cmd+opt+b",
+  //       "canvasEqualizeWidths" : "",
+  //       "canvasEqualizeHeights" : "",
+  //       "reopenPreviousSession" : "cmd+shift+o",
+  //       "sendCtrlFToTerminal" : "",
+  //       "browserZoomReset" : "cmd+0",
+  //       "newBrowserWorkspace" : "cmd+opt+n",
+  //       "markdownZoomIn" : "cmd+=",
+  //       "openFolder" : "cmd+o",
+  //       "canvasAlignLeft" : "",
+  //       "canvasAlignTop" : "",
+  //       "diffViewerScrollToBottom" : "shift+g",
+  //       "find" : "cmd+f",
+  //       "toggleBrowserFocusMode" : "cmd+opt+\r",
+  //       "canvasDistributeVertically" : "",
+  //       "sendFeedback" : "",
+  //       "saveFilePreview" : "cmd+s"
+  //     }
+  //   },
+}

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,57 @@
+
+# This is the configuration file for Ghostty.
+#
+# This template file has been automatically created at the following
+# path since Ghostty couldn't find any existing config files on your system:
+#
+#   /Users/roy/Library/Application Support/com.mitchellh.ghostty/config
+#
+# The template does not set any default options, since Ghostty ships
+# with sensible defaults for all options. Users should only need to set
+# options that they want to change from the default.
+#
+# Run `ghostty +show-config --default --docs` to view a list of
+# all available config options and their default values.
+#
+# Additionally, each config option is also explained in detail
+# on Ghostty's website, at https://ghostty.org/docs/config.
+#
+# Ghostty can reload the configuration while running by using the menu
+# options or the bound key (default: Command + Shift + comma on macOS and
+# Control + Shift + comma on other platforms). Not all config options can be
+# reloaded while running; some only apply to new windows and others may require
+# a full restart to take effect.
+
+# Config syntax crash course
+# ==========================
+# # The config file consists of simple key-value pairs,
+# # separated by equals signs.
+# font-family = Iosevka
+# window-padding-x = 2
+#
+# # Spacing around the equals sign does not matter.
+# # All of these are identical:
+# key=value
+# key= value
+# key =value
+# key = value
+#
+# # Any line beginning with a # is a comment. It's not possible to put
+# # a comment after a config option, since it would be interpreted as a
+# # part of the value. For example, this will have a value of "#123abc":
+# background = #123abc
+#
+# # Empty values are used to reset config keys to default.
+# key =
+#
+# # Some config options have unique syntaxes for their value,
+# # which is explained in the docs for that config option.
+# # Just for example:
+# resize-overlay-duration = 4s 200ms
+font-family = "PlemolJP35 Console NF"
+font-size = 14
+theme = Cyberpunk
+command = ~/.local/bin/fish
+macos-secure-input-indication = false
+keybind = super+space=ignore
+copy-on-select = clipboard

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -129,6 +129,18 @@ create_symlink $BASE_DIR/jjconfig.toml ~/.config/jj/config.toml "jujutsu config"
 
 echo ""
 
+# cmux設定ファイル
+echo "Setting up cmux configuration..."
+create_symlink $BASE_DIR/cmux ~/.config/cmux "cmux configuration"
+
+echo ""
+
+# ghostty設定ファイル
+echo "Setting up ghostty configuration..."
+create_symlink $BASE_DIR/ghostty ~/.config/ghostty "ghostty configuration"
+
+echo ""
+
 # SSH設定ファイル（Bitwarden SSH agent を IdentityAgent で常用）
 echo "🔑 Setting up SSH configuration..."
 create_symlink $BASE_DIR/ssh/config ~/.ssh/config "SSH config"


### PR DESCRIPTION
## 概要

cmux 関連のスキル群と設定を dotsfile 管理下に追加する。

## 変更内容

- `.agents/skills/cmux-*` : cmux 用スキル群を追加（`claude/skills/` から symlink）
- `cmux/cmux.json` : cmux 設定を追加（`~/.config/cmux` へ symlink）
  - `markdown.fontFamily` = PlemolJP35 Console NF
  - `automation.ripgrepBinaryPath` = devbox の rg を絶対パス指定（`~` 展開非依存で確実に解決）
  - `terminal.agentHibernation` 有効化（idle 60s / max 12）
- `ghostty/config` : Ghostty 設定を追加
- `scripts/build_env/setup_fish.sh` : cmux 設定の symlink 作成処理を追加

## 確認済み

- `~/.config/cmux` → repo への symlink が正常
- `ripgrepBinaryPath` のバイナリ実在（rg 15.1.0）
- `markdown.fontFamily` のフォントがインストール済み

https://claude.ai/code/session_01J4AQrEBDs5nsA91kUoPLmz