### PR TITLE
feat: fuguレビュースキル追加とcursorレビューのComposer 2.5化

### DIFF
--- a/claude/rules/cursor-delegation.md
+++ b/claude/rules/cursor-delegation.md
@@ -17,7 +17,7 @@ Cursor Agent はレビューと実装委譲に使う。**実装は積極的に C
 
 ## 委譲方法
 
-- `/cursor [レビュー指示]` でレビュー依頼（GPT-5.5 High + code-reviewer の並行レビュー）
+- `/cursor [レビュー指示]` でレビュー依頼（Composer 2.5 + code-reviewer の並行レビュー）
 - `/cursor-impl [実装指示]` で実装委譲（Composer 2.5）
 
 ## 実装委譲の原則

--- a/claude/skills/cursor/SKILL.md
+++ b/claude/skills/cursor/SKILL.md
@@ -17,8 +17,7 @@ Cursor AgentとClaude自身で並行レビューを実行するスキル。
 
 1. ユーザーのレビュー対象・観点を整理
 2. 以下を**並行**で実行する:
-   - Bashで `cursor-agent -p --trust --mode ask --model gpt-5.5-high "プロンプト"` を実行（headless / read-only Q&A）
-     - `gpt-5.5-high` が使用制限（usage limit / rate limit）で止まった場合は `--model composer-2.5` に切り替えて再実行する
+   - Bashで `cursor-agent -p --trust --mode ask --model composer-2.5 "プロンプト"` を実行（headless / read-only Q&A）
    - Agentツールで `code-reviewer` サブエージェントを起動し、同じ観点でレビュー
 3. 両方の結果を統合して報告する:
    - 両者が一致する指摘 → 確度が高い
@@ -27,9 +26,7 @@ Cursor AgentとClaude自身で並行レビューを実行するスキル。
 
 ## モデル
 
-`gpt-5.5-high`（GPT-5.5 1M High）。長考型でレビューの推論精度が高い。
-`gpt-5.5-high` が使用制限で止まった場合は `composer-2.5` にフォールバックする。
-実装特化のレビューに切り替えたい場合も `composer-2.5` を使う。
+`composer-2.5`（Composer 2.5）。実装特化で速い。
 変更したい場合は `cursor-agent --list-models` で一覧確認。
 
 ## 関連スキル

--- a/claude/skills/fugu/SKILL.md
+++ b/claude/skills/fugu/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: fugu
+description: Sakana Fugu (codex CLI) でコードレビューを実行
+metadata:
+  target_agent: claude
+---
+
+# /fugu
+
+Sakana FuguとClaude自身で並行レビューを実行するスキル。
+
+## コマンド
+
+- `/fugu [指示]` - コードレビュー
+
+## 実行手順
+
+1. ユーザーのレビュー対象・観点を整理
+2. 以下を**並行**で実行する:
+   - Bashで `codex exec -p fugu -s read-only --skip-git-repo-check "プロンプト" < /dev/null` を実行（headless / read-only）
+   - Agentツールで `code-reviewer` サブエージェントを起動し、同じ観点でレビュー
+3. 両方の結果を統合して報告する:
+   - 両者が一致する指摘 → 確度が高い
+   - 片方のみの指摘 → 補足として報告
+   - 矛盾する指摘 → 両方の見解を併記
+
+## モデル
+
+`fugu`（Sakana Fugu 1M / reasoning high）。長考型でレビューの推論精度が高い。
+さらに深い推論が欲しい場合は `-p fugu-ultra` に切り替える。
+`-s read-only` で編集させず読み取り専用にする。`--skip-git-repo-check` でリポジトリ外でも動く。
+`< /dev/null` でstdin待ちブロックを防ぐ。
+
+## 関連スキル
+
+- 同じ並行レビューをCursor Agentで行う場合は `/cursor`

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,0 +1,40 @@
+model = "gpt-5.5"
+personality = "pragmatic"
+[projects."/Users/roy/.config/fish"]
+trust_level = "trusted"
+
+[projects."/Users/roy/ghq/github.com/RoyMcCrain/dotsfile"]
+trust_level = "trusted"
+
+[projects."/Users/roy/ghq/github.com/zero-color/crm"]
+trust_level = "trusted"
+
+[projects."/Users/roy/ghq/github.com/zero-color/agf-cocoro-hitoiki-shopify-app"]
+trust_level = "trusted"
+
+[projects."/Users/roy/ghq/github.com/zero-color/agf-mall-shopify-app"]
+trust_level = "trusted"
+
+[projects."/Users/roy/ghq/github.com/zero-color/agf-mall-shopify-theme"]
+trust_level = "trusted"
+
+[features]
+rmcp_client = true
+
+[notice]
+hide_gpt5_1_migration_prompt = true
+"hide_gpt-5.1-codex-max_migration_prompt" = true
+
+[notice.model_migrations]
+"gpt-5.1-codex-max" = "gpt-5.2-codex"
+"gpt-5.2-codex" = "gpt-5.4"
+
+# Sakana Fugu (profile は ~/.codex/fugu.config.toml に分離)
+[model_providers.sakana]
+name = "Sakana API"
+base_url = "https://api.sakana.ai/v1"
+env_key = "FUGU_API_KEY"
+wire_api = "responses"
+stream_idle_timeout_ms = 7200000
+stream_max_retries = 5
+request_max_retries = 4

--- a/codex/fugu.config.toml
+++ b/codex/fugu.config.toml
@@ -1,0 +1,8 @@
+model = "fugu"
+model_reasoning_effort = "high"
+model_provider = "sakana"
+model_catalog_json = "~/.codex/fugu.json"
+
+[features]
+image_generation = false
+apps = false

--- a/codex/fugu.json
+++ b/codex/fugu.json
@@ -1,0 +1,60 @@
+{
+  "models": [
+    {
+      "slug": "fugu",
+      "display_name": "Fugu",
+      "context_window": 1000000,
+      "supported_reasoning_levels": [
+        {
+          "effort": "high",
+          "description": "Deep reasoning for complex problems"
+        }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 0,
+      "base_instructions": "Before recommending or running any command that could stop, restart, or replace the environment you are running in — e.g. `wsl --shutdown` / `wsl --terminate`, host or VM reboot, `systemctl`/service restarts of your runtime, or killing your own shell, container, or session processes — first determine whether you are executing inside that same environment. If you might be, do not run it yourself: warn the user explicitly that the command will end this session and your ability to help until it is restarted, give the exact recovery steps, and let the user run it manually when they are ready.\n\nNever force-kill processes by raw PID against arbitrary or unknown PID lists (e.g. `kill -9`, `Stop-Process -Force`, `taskkill /F`): the agent runtime depends on its own child processes, and force-killing them can permanently break the session. To stop a dev server or free a port, stop the owning task by name; otherwise ask the user before terminating any PID.",
+      "supports_reasoning_summaries": false,
+      "default_reasoning_summary": "none",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "input_modalities": ["text", "image"],
+      "truncation_policy": {
+        "mode": "tokens",
+        "limit": 10000
+      },
+      "supports_parallel_tool_calls": true,
+      "experimental_supported_tools": []
+    },
+    {
+      "slug": "fugu-ultra",
+      "display_name": "Fugu Ultra",
+      "context_window": 1000000,
+      "supported_reasoning_levels": [
+        {
+          "effort": "high",
+          "description": "Deep reasoning for complex problems"
+        }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 1,
+      "base_instructions": "Before recommending or running any command that could stop, restart, or replace the environment you are running in — e.g. `wsl --shutdown` / `wsl --terminate`, host or VM reboot, `systemctl`/service restarts of your runtime, or killing your own shell, container, or session processes — first determine whether you are executing inside that same environment. If you might be, do not run it yourself: warn the user explicitly that the command will end this session and your ability to help until it is restarted, give the exact recovery steps, and let the user run it manually when they are ready.\n\nNever force-kill processes by raw PID against arbitrary or unknown PID lists (e.g. `kill -9`, `Stop-Process -Force`, `taskkill /F`): the agent runtime depends on its own child processes, and force-killing them can permanently break the session. To stop a dev server or free a port, stop the owning task by name; otherwise ask the user before terminating any PID.",
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": false,
+      "default_verbosity": null,
+      "apply_patch_tool_type": "freeform",
+      "input_modalities": ["text", "image"],
+      "truncation_policy": {
+        "mode": "tokens",
+        "limit": 10000
+      },
+      "supports_parallel_tool_calls": true,
+      "experimental_supported_tools": []
+    }
+  ]
+}

--- a/fish/abbreviations.fish
+++ b/fish/abbreviations.fish
@@ -36,6 +36,7 @@ abbr mkdir 'mkdir -p'
 # Editor and tools
 abbr a 'nvim'
 abbr cur 'cursor-agent'
+abbr fugu 'codex -p fugu' # codex with Sakana Fugu profile
 abbr code 'code -n .' # vscode
 abbr exp 'explorer.exe .' # explorer
 

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -60,6 +60,9 @@ ln -sf ${BASE_DIR}/claude/settings.json ~/.claude/settings.json
 mkdir -p ~/.codex/skills
 ln -sf ${BASE_DIR}/codex/AGENTS.md ~/.codex/AGENTS.md
 ln -sf ${BASE_DIR}/codex/instructions.md ~/.codex/instructions.md
+ln -sf ${BASE_DIR}/codex/config.toml ~/.codex/config.toml
+ln -sf ${BASE_DIR}/codex/fugu.json ~/.codex/fugu.json
+ln -sf ${BASE_DIR}/codex/fugu.config.toml ~/.codex/fugu.config.toml
 ln -sf ${BASE_DIR}/codex/skills/context-loader ~/.codex/skills/context-loader
 
 # Gemini


### PR DESCRIPTION
## 概要

codex CLI経由でSakana Fuguを使うコードレビュースキル `/fugu` を追加。あわせて `/cursor` のレビューモデルをComposer 2.5にデフォルト変更。

## 変更内容

- **`/fugu` スキル追加**: `codex exec -p fugu -s read-only` でFugu + Claude `code-reviewer` の並行レビュー(`/cursor` をミラー)
- **codex設定をdotsfile管理化**: `config.toml` / `fugu.config.toml` / `fugu.json`(Sakana Fugu プロファイル)
- **`/cursor` をComposer 2.5化**: レビューモデルのデフォルトを `gpt-5.5-high` → `composer-2.5` に変更(skill + cursor-delegation rule)

## 動作確認

- `codex exec -p fugu -s read-only` でFuguが応答することを確認済み

## 役割分担

- `/fugu` — Sakana Fugu(長考・高精度)で並行レビュー
- `/cursor` — Composer 2.5(実装特化・速い)で並行レビュー

https://claude.ai/code/session_01B2w6cBPpQb7XXMJpwWs8yX