### PR TITLE
feat: cursor/fuguレビュースキルをcursor+fugu並行構成に統合

### DIFF
--- a/claude/skills/cursor/SKILL.md
+++ b/claude/skills/cursor/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # /cursor
 
-Cursor AgentとClaude自身で並行レビューを実行するスキル。
+Cursor Agent (Composer 2.5) と Sakana Fugu (codex) で並行レビューを実行するスキル。
 
 ## コマンド
 
@@ -18,7 +18,7 @@ Cursor AgentとClaude自身で並行レビューを実行するスキル。
 1. ユーザーのレビュー対象・観点を整理
 2. 以下を**並行**で実行する:
    - Bashで `cursor-agent -p --trust --mode ask --model composer-2.5 "プロンプト"` を実行（headless / read-only Q&A）
-   - Agentツールで `code-reviewer` サブエージェントを起動し、同じ観点でレビュー
+   - Bashで `codex exec -p fugu -s read-only --skip-git-repo-check "プロンプト" < /dev/null` を実行（headless / read-only）
 3. 両方の結果を統合して報告する:
    - 両者が一致する指摘 → 確度が高い
    - 片方のみの指摘 → 補足として報告
@@ -26,9 +26,10 @@ Cursor AgentとClaude自身で並行レビューを実行するスキル。
 
 ## モデル
 
-`composer-2.5`（Composer 2.5）。実装特化で速い。
-変更したい場合は `cursor-agent --list-models` で一覧確認。
+- Cursor: `composer-2.5`（Composer 2.5）。実装特化で速い。変更したい場合は `cursor-agent --list-models` で一覧確認。
+- Fugu: `fugu`（Sakana Fugu 1M / reasoning high）。長考型で推論精度が高い。さらに深い推論が欲しい場合は `-p fugu-ultra`。`-s read-only` で読み取り専用、`--skip-git-repo-check` でリポジトリ外でも動く、`< /dev/null` でstdin待ちブロックを防ぐ。
 
 ## 関連スキル
 
+- `/fugu` も同じ cursor + fugu 並行レビューを行う（相互エイリアス）
 - 実装まで委譲する場合は `/cursor-impl`（Composer 2.5 に write/shell 込みで実装させる）

--- a/claude/skills/fugu/SKILL.md
+++ b/claude/skills/fugu/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # /fugu
 
-Sakana FuguとClaude自身で並行レビューを実行するスキル。
+Sakana Fugu (codex) と Cursor Agent (Composer 2.5) で並行レビューを実行するスキル。
 
 ## コマンド
 
@@ -18,7 +18,7 @@ Sakana FuguとClaude自身で並行レビューを実行するスキル。
 1. ユーザーのレビュー対象・観点を整理
 2. 以下を**並行**で実行する:
    - Bashで `codex exec -p fugu -s read-only --skip-git-repo-check "プロンプト" < /dev/null` を実行（headless / read-only）
-   - Agentツールで `code-reviewer` サブエージェントを起動し、同じ観点でレビュー
+   - Bashで `cursor-agent -p --trust --mode ask --model composer-2.5 "プロンプト"` を実行（headless / read-only Q&A）
 3. 両方の結果を統合して報告する:
    - 両者が一致する指摘 → 確度が高い
    - 片方のみの指摘 → 補足として報告
@@ -26,11 +26,9 @@ Sakana FuguとClaude自身で並行レビューを実行するスキル。
 
 ## モデル
 
-`fugu`（Sakana Fugu 1M / reasoning high）。長考型でレビューの推論精度が高い。
-さらに深い推論が欲しい場合は `-p fugu-ultra` に切り替える。
-`-s read-only` で編集させず読み取り専用にする。`--skip-git-repo-check` でリポジトリ外でも動く。
-`< /dev/null` でstdin待ちブロックを防ぐ。
+- Fugu: `fugu`（Sakana Fugu 1M / reasoning high）。長考型でレビューの推論精度が高い。さらに深い推論が欲しい場合は `-p fugu-ultra` に切り替える。`-s read-only` で編集させず読み取り専用にする。`--skip-git-repo-check` でリポジトリ外でも動く。`< /dev/null` でstdin待ちブロックを防ぐ。
+- Cursor: `composer-2.5`（Composer 2.5）。実装特化で速い。変更したい場合は `cursor-agent --list-models` で一覧確認。
 
 ## 関連スキル
 
-- 同じ並行レビューをCursor Agentで行う場合は `/cursor`
+- `/cursor` も同じ cursor + fugu 並行レビューを行う（相互エイリアス）


### PR DESCRIPTION
## 概要

`/cursor` と `/fugu` の並行レビュースキルを、どちらも **Cursor Composer 2.5 + Sakana Fugu** の2系統並行レビューに統合しました。

## 変更内容

| スキル | Before | After |
|--------|--------|-------|
| `/cursor` | cursor + Claude自身(code-reviewer) | **cursor + fugu** |
| `/fugu` | fugu + Claude自身(code-reviewer) | **cursor + fugu** |

- Claude自身の `code-reviewer` サブエージェント呼び出しを外し、両スキルとも外部CLI 2系統の並行実行に統一
- どちらを叩いても同じ2系統レビューになる相互エイリアスとして記載
- 結果統合ロジック（一致＝高確度／片方のみ＝補足／矛盾＝併記）はそのまま維持

https://claude.ai/code/session_011fb92Pfb33acLCEhJ8khFA