### PR TITLE
feat(fish): FUGU_API_KEYをBitwarden→Keychain経由に変更

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -21,6 +21,10 @@ set -gx EDITOR nvim
 set -gx TERM xterm-256color
 set -gx DFT_DISPLAY side-by-side-show-both
 
+# FUGU_API_KEY (Bitwarden→Keychainキャッシュ。更新は sync-fugu-key)
+set -l fugu_key (security find-generic-password -s fugu-api-key -w 2>/dev/null)
+test -n "$fugu_key"; and set -gx FUGU_API_KEY $fugu_key
+
 # devbox
 # SSH の Match exec が $SHELL を execve するため絶対パスを設定する（裸の "fish" だと exec 失敗）
 set -gx SHELL (status fish-path)

--- a/fish/functions/sync-fugu-key.fish
+++ b/fish/functions/sync-fugu-key.fish
@@ -1,0 +1,22 @@
+function sync-fugu-key --description 'Sync FUGU_API_KEY from Bitwarden into macOS Keychain'
+    if not command -q bw
+        echo "bw: 実行ファイルが見つかりません" >&2
+        return 127
+    end
+
+    if test -z "$BW_SESSION"
+        echo "BW_SESSION 未設定。先に bw-unlock を実行してください" >&2
+        return 1
+    end
+
+    bw sync
+    set -l key (bw get password fugu-api-key)
+    if test -z "$key"
+        echo "sync-fugu-key: Bitwarden から取得できませんでした" >&2
+        return 1
+    end
+
+    security add-generic-password -U -s fugu-api-key -a $USER -w $key
+    set -gx FUGU_API_KEY $key
+    echo "FUGU_API_KEY を Keychain に保存し、現在のシェルにも反映しました"
+end


### PR DESCRIPTION
## 背景

`~/.envrc`(direnv)に `FUGU_API_KEY` を置いていたが、direnvはディレクトリスコープのため **HOME 以外で起動すると伝播せず fugu が動かない**問題があった。

## 変更

どのディレクトリで起動しても効くよう、グローバルな秘密として Keychain 経由に変更（真実の源は Bitwarden）。

- `fish/config.fish`: 起動時に macOS Keychain から `FUGU_API_KEY` を読んで export
- `fish/functions/sync-fugu-key.fish`: 新規。`bw sync` → `bw get` → Keychain 同期（GUI編集がCLIに反映されない問題対策で `bw sync` 込み）

## 運用

値の更新時:
```fish
bw-unlock
sync-fugu-key
```

## 動作確認

`codex exec -p fugu -s read-only` が 401 解消して正常応答（`OK`）することを確認済み。

https://claude.ai/code/session_015pCwLjSCp6K6ay58d7Aayo