### PR TITLE
[codex] add Pi coding agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ __pycache__/
 
 # Codex local profile state (hook trust etc.)
 codex/fugu.config.toml
+
+# Pi local secrets / generated state
+pi/agent/auth.json
+pi/agent/trust.json
+pi/agent/sessions/
+pi/agent/git/
+pi/agent/npm/

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -59,7 +59,7 @@
   "shell": {
     "init_hook": [],
     "scripts": {
-      "setup-npm": "npm install -g neovim typescript @typescript/native-preview @openai/codex cf firecrawl-cli"
+      "setup-npm": "npm install -g neovim typescript @typescript/native-preview @openai/codex cf firecrawl-cli && npm install -g --ignore-scripts --min-release-age=0 @earendil-works/pi-coding-agent"
     }
   }
 }

--- a/fish/abbreviations.fish
+++ b/fish/abbreviations.fish
@@ -43,11 +43,11 @@ abbr exp 'explorer.exe .' # explorer
 abbr sortp 'npx sort-package-json'
 
 # pnpm
-abbr p 'pnpm'
-abbr pr 'pnpm run'
-abbr pi 'pnpm i'
-abbr pa 'pnpm add'
-abbr px 'pnpm dlx'
+abbr pn 'pnpm'
+abbr pnr 'pnpm run'
+abbr pni 'pnpm i'
+abbr pna 'pnpm add'
+abbr pnx 'pnpm dlx'
 
 # ghq shortcuts
 abbr ghq-get 'ghq-get-cd'

--- a/pi/README.md
+++ b/pi/README.md
@@ -55,10 +55,31 @@ Tracked custom providers:
 Environment variables:
 
 ```bash
-export SAKANA_API_KEY="..."              # Sakana provider in models.json
 export LM_STUDIO_BASE_URL="http://localhost:1234/v1"  # Optional
 export LM_STUDIO_API_KEY="..."           # Optional; dummy key is used if unset
 ```
+
+### Sakana API key
+
+`sakana-ai-console` is a custom provider, so keep its key in Pi's auth file. The
+tracked example uses Bitwarden CLI and contains no secret:
+
+```bash
+cp pi/agent/auth.json.example ~/.pi/agent/auth.json
+chmod 600 ~/.pi/agent/auth.json
+```
+
+Before starting Pi, unlock Bitwarden in the same shell so `bw get password` can
+return the key:
+
+```fish
+set -gx BW_SESSION (bw unlock --raw)
+bw sync
+pi
+```
+
+If you do not want to use Bitwarden, edit `~/.pi/agent/auth.json` and store a
+literal API key or an environment reference such as `$SAKANA_API_KEY`.
 
 ## Extensions
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,81 @@
+# Pi Coding Agent config
+
+`pi/agent` is intended to be linked to Pi's global config directory
+(`~/.pi/agent`). Keep secrets out of this repository: use environment variables,
+Bitwarden CLI commands, or `~/.pi/agent/auth.json`.
+
+## Install
+
+Pi is installed by the global devbox npm setup:
+
+```bash
+devbox global run setup-npm
+```
+
+Manual install:
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+## Link this config
+
+The dotfiles setup scripts link the tracked files into `~/.pi/agent` without
+touching `auth.json`:
+
+```bash
+./scripts/build_env/setup_fish.sh
+```
+
+For one-off testing without symlinks:
+
+```bash
+PI_CODING_AGENT_DIR=$PWD/pi/agent pi --list-models
+PI_CODING_AGENT_DIR=$PWD/pi/agent pi
+```
+
+## Model setup
+
+Use Pi's built-in subscription flow when possible:
+
+```text
+/login
+/model
+```
+
+The default model is `sakana-ai-console/fugu-ultra` (set in `settings.json`).
+
+Tracked custom providers:
+
+- `sakana-ai-console/fugu`
+- `sakana-ai-console/fugu-ultra`
+- `lm-studio/*` (dynamically loaded from `LM_STUDIO_BASE_URL` or
+  `http://localhost:1234/v1`)
+
+Environment variables:
+
+```bash
+export SAKANA_API_KEY="..."              # Sakana provider in models.json
+export LM_STUDIO_BASE_URL="http://localhost:1234/v1"  # Optional
+export LM_STUDIO_API_KEY="..."           # Optional; dummy key is used if unset
+```
+
+## Extensions
+
+Configured by `settings.json` via `extensions/*.ts`.
+
+| Extension         | Purpose                                                              |
+| ----------------- | -------------------------------------------------------------------- |
+| `local-openai.ts` | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
+
+Reload after editing extensions:
+
+```text
+/reload
+```
+
+## Skills
+
+Do not duplicate shared skills here. Pi automatically discovers
+`~/.agents/skills/`, so Firecrawl and other shared agent skills are loaded from
+the existing agents skill directory.

--- a/pi/README.md
+++ b/pi/README.md
@@ -62,23 +62,21 @@ export LM_STUDIO_API_KEY="..."           # Optional; dummy key is used if unset
 ### Sakana API key
 
 `sakana-ai-console` is a custom provider, so keep its key in Pi's auth file. The
-tracked example uses Bitwarden CLI and contains no secret:
+tracked example reads the key directly from macOS Keychain and contains no
+secret:
 
 ```bash
 cp pi/agent/auth.json.example ~/.pi/agent/auth.json
 chmod 600 ~/.pi/agent/auth.json
 ```
 
-Before starting Pi, unlock Bitwarden in the same shell so `bw get password` can
-return the key:
+The example expects a generic password item named `fugu-api-key`:
 
-```fish
-set -gx BW_SESSION (bw unlock --raw)
-bw sync
-pi
+```bash
+security find-generic-password -w -s fugu-api-key >/dev/null
 ```
 
-If you do not want to use Bitwarden, edit `~/.pi/agent/auth.json` and store a
+If you do not want to use Keychain, edit `~/.pi/agent/auth.json` and store a
 literal API key or an environment reference such as `$SAKANA_API_KEY`.
 
 ## Extensions

--- a/pi/agent/auth.json.example
+++ b/pi/agent/auth.json.example
@@ -1,6 +1,6 @@
 {
   "sakana-ai-console": {
     "type": "api_key",
-    "key": "!bw get password fugu-api-key"
+    "key": "!security find-generic-password -w -s fugu-api-key"
   }
 }

--- a/pi/agent/auth.json.example
+++ b/pi/agent/auth.json.example
@@ -1,0 +1,6 @@
+{
+  "sakana-ai-console": {
+    "type": "api_key",
+    "key": "!bw get password sakana-api-key"
+  }
+}

--- a/pi/agent/auth.json.example
+++ b/pi/agent/auth.json.example
@@ -1,6 +1,6 @@
 {
   "sakana-ai-console": {
     "type": "api_key",
-    "key": "!bw get password sakana-api-key"
+    "key": "!bw get password fugu-api-key"
   }
 }

--- a/pi/agent/extensions/local-openai.ts
+++ b/pi/agent/extensions/local-openai.ts
@@ -1,0 +1,62 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+interface ModelList {
+  data?: Array<{
+    id: string;
+    name?: string;
+    context_window?: number;
+    max_tokens?: number;
+  }>;
+}
+
+const fetchWithTimeout = async (url: string, timeoutMs: number) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export default async function localOpenAI(pi: ExtensionAPI) {
+  const baseUrl = process.env.LM_STUDIO_BASE_URL || "http://localhost:1234/v1";
+
+  try {
+    const response = await fetchWithTimeout(`${baseUrl}/models`, 1500);
+    if (!response.ok) return;
+
+    const payload = (await response.json()) as ModelList;
+    const models = payload.data ?? [];
+    if (models.length === 0) return;
+
+    pi.registerProvider("lm-studio", {
+      name: "LM Studio",
+      baseUrl,
+      apiKey: process.env.LM_STUDIO_API_KEY
+        ? "$LM_STUDIO_API_KEY"
+        : "lm-studio",
+      api: "openai-completions",
+      models: models.map((model) => ({
+        id: model.id,
+        name: model.name ?? model.id,
+        reasoning: false,
+        input: ["text"],
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+        contextWindow: model.context_window ?? 128000,
+        maxTokens: model.max_tokens ?? 4096,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+        },
+      })),
+    });
+  } catch {
+    // Local endpoints are optional; keep Pi startup quiet when LM Studio is offline.
+  }
+}

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -1,0 +1,40 @@
+{
+  "providers": {
+    "sakana-ai-console": {
+      "name": "Sakana AI Console",
+      "baseUrl": "https://api.sakana.ai/v1",
+      "api": "openai-responses",
+      "apiKey": "$SAKANA_API_KEY",
+      "models": [
+        {
+          "id": "fugu",
+          "name": "Sakana Fugu",
+          "reasoning": false,
+          "input": ["text"],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 128000,
+          "maxTokens": 32768
+        },
+        {
+          "id": "fugu-ultra",
+          "name": "Sakana Fugu Ultra",
+          "reasoning": false,
+          "input": ["text"],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 128000,
+          "maxTokens": 32768
+        }
+      ]
+    }
+  }
+}

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -4,13 +4,14 @@
       "name": "Sakana AI Console",
       "baseUrl": "https://api.sakana.ai/v1",
       "api": "openai-responses",
-      "apiKey": "$SAKANA_API_KEY",
       "models": [
         {
           "id": "fugu",
           "name": "Sakana Fugu",
           "reasoning": false,
-          "input": ["text"],
+          "input": [
+            "text"
+          ],
           "cost": {
             "input": 0,
             "output": 0,
@@ -24,7 +25,9 @@
           "id": "fugu-ultra",
           "name": "Sakana Fugu Ultra",
           "reasoning": false,
-          "input": ["text"],
+          "input": [
+            "text"
+          ],
           "cost": {
             "input": 0,
             "output": 0,

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,0 +1,25 @@
+{
+  "defaultProvider": "sakana-ai-console",
+  "defaultModel": "fugu-ultra",
+  "defaultThinkingLevel": "medium",
+  "theme": "dark",
+  "defaultProjectTrust": "ask",
+  "enableInstallTelemetry": false,
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  },
+  "retry": {
+    "enabled": true,
+    "maxRetries": 3,
+    "baseDelayMs": 2000,
+    "provider": {
+      "maxRetries": 0,
+      "maxRetryDelayMs": 60000
+    }
+  },
+  "extensions": [
+    "extensions/*.ts"
+  ]
+}

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -112,6 +112,14 @@ for SKILL in ${BASE_DIR}/claude/skills/*; do
   if [ ! -f "${SOURCE}/SKILL.md" ]; then
     continue
   fi
+
+  # Codex 独自 skill（codex/skills/* 実体）が同名で存在する場合は
+  # Codex 向けに調整済みなので claude 版で上書きしない。
+  if [ -f "${BASE_DIR}/codex/skills/${NAME}/SKILL.md" ]; then
+    echo "skip (codex-native skill): ${NAME}"
+    continue
+  fi
+
   DEST=~/.codex/skills/${NAME}
   # Codex 側に実ディレクトリ（非 symlink）が既にある場合は保護してスキップ
   if [ -e "${DEST}" ] && [ ! -L "${DEST}" ]; then
@@ -127,3 +135,10 @@ mkdir -p ~/.gemini/antigravity-cli/skills
 ln -sf ${BASE_DIR}/antigravity/AGENTS.md ~/.gemini/antigravity-cli/AGENTS.md
 ln -sf ${BASE_DIR}/antigravity/instructions.md ~/.gemini/antigravity-cli/instructions.md
 ln -sf ${BASE_DIR}/antigravity/skills/context-loader ~/.gemini/antigravity-cli/skills/context-loader
+
+# Pi Coding Agent
+# auth.json は秘密情報/OAuth を含むためリンクしない。
+mkdir -p ~/.pi/agent
+ln -sf ${BASE_DIR}/pi/agent/settings.json ~/.pi/agent/settings.json
+ln -sf ${BASE_DIR}/pi/agent/models.json ~/.pi/agent/models.json
+ln -sfn ${BASE_DIR}/pi/agent/extensions ~/.pi/agent/extensions

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -185,6 +185,17 @@ end
 
 echo ""
 
+echo "🤖 Setting up Pi Coding Agent configuration..."
+set PI_AGENT_DIR ~/.pi/agent
+if not test -d $PI_AGENT_DIR
+    mkdir -p $PI_AGENT_DIR
+end
+create_symlink $BASE_DIR/pi/agent/settings.json $PI_AGENT_DIR/settings.json "Pi settings"
+create_symlink $BASE_DIR/pi/agent/models.json $PI_AGENT_DIR/models.json "Pi custom models"
+create_symlink $BASE_DIR/pi/agent/extensions $PI_AGENT_DIR/extensions "Pi extensions"
+
+echo ""
+
 echo "🎉 Fish configuration setup completed!"
 echo ""
 echo "📋 Next steps:"


### PR DESCRIPTION
## Summary

- add tracked Pi Coding Agent config under `pi/agent`
- register Sakana AI Console `fugu` / `fugu-ultra` custom models and default Pi to `fugu-ultra`
- add a local LM Studio provider extension and symlink Pi config from setup scripts
- install Pi via the global devbox npm setup and free the `pi` command from Fish pnpm abbreviations
- ignore Pi local auth/session/generated state

## Validation

- `deno fmt --check pi/README.md pi/agent/settings.json pi/agent/models.json pi/agent/auth.json.example pi/agent/extensions/*.ts`
- `jq -e . pi/agent/settings.json`
- `jq -e . pi/agent/models.json`
- `jq -e . pi/agent/auth.json.example`
- `fish -n scripts/build_env/setup_fish.sh`
- `zsh -n scripts/build_env/create_symlink.sh`
- `SAKANA_API_KEY=dummy PI_CODING_AGENT_DIR=$PWD/pi/agent PI_OFFLINE=1 pi --list-models sakana`

## Notes

Pi already auto-discovers shared skills from `~/.agents/skills`, so this PR does not duplicate Firecrawl skills under `pi/agent/skills`.
