### PR TITLE
feat(pi): AGENTS.md グローバルコンテキスト追加と routing-critical skills のリンク

### DIFF
--- a/codex/skills/codex-review/SKILL.md
+++ b/codex/skills/codex-review/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: codex-review
+description: Codex CLIでコードレビューを実行。Use when the user asks for a Codex-based review, Codex review skill, code review with Codex, PR/diff review by Codex, or wants a second-pass review separate from the current agent. Runs headless Codex in read-only mode and reports findings in Japanese.
+metadata:
+  target_agent: Codex
+---
+
+# /codex-review
+
+Codex CLI を headless/read-only で起動し、現在の変更・PR・指定範囲をレビューするスキル。
+
+## コマンド
+
+- `/codex-review [レビュー対象・観点]` - Codex によるコードレビュー
+- Pi で明示実行する場合は `/skill:codex-review [レビュー対象・観点]`
+
+## 実行手順
+
+1. レビュー対象を決める。
+   - 指定があればそれを使う（PR番号/URL、ファイル、差分範囲、観点）。
+   - 指定がなければ現在の作業ツリー差分を対象にする。
+2. レビュー用プロンプトを作る。
+   - 「修正しない」「レビューだけ」「重大度順」「ファイル/行/理由/修正案」を明記する。
+   - `.jj` があれば jj 前提で差分確認するよう明記する。
+   - 秘密 env ファイルを読まないよう明記する。
+3. Bash で Codex CLI を headless 実行する。
+
+```bash
+codex exec -p fugu -m fugu-ultra -s read-only --skip-git-repo-check --ephemeral "レビュー用プロンプト" < /dev/null
+```
+
+   - `-p fugu` は `~/.codex/fugu.config.toml` を読み込むための profile 指定。
+   - `-m fugu-ultra` で Fugu Ultra を明示する。
+   - `-s read-only` で編集・書き込みを禁止する。
+   - `--ephemeral` でレビュー用セッションを保存しない。
+   - `--skip-git-repo-check` でリポジトリ外でも動く。
+   - `< /dev/null` で stdin 待ちブロックを防ぐ。
+
+4. 結果を精査して報告する。
+   - 事実確認できる指摘だけ採用する。
+   - 不確かな指摘は「要確認」として分ける。
+   - 重大な指摘を先に出す。
+
+## 推奨プロンプト
+
+```text
+あなたは厳格なコードレビュアーです。以下をレビューしてください。
+
+対象: {対象}
+観点: {観点 or バグ、セキュリティ、設計逸脱、テスト不足、回帰リスク}
+
+制約:
+- ファイルは編集しない
+- コマンド実行は読み取り系だけにする
+- `.jj` がある場合は git ではなく jj で状態と差分を確認する
+- 秘密envファイル（.env / .env.local / .env.*.local / .envrc.local）は読まない
+
+出力:
+- 重大度順
+- 各指摘に ファイル/行、問題、理由、修正案 を含める
+- 指摘なしなら「重大な問題なし」と明記する
+```
+
+## 出力統合ルール
+
+- Codex の出力をそのまま貼らず、現在の agent が要点を再整理する。
+- レビュー指摘は `Critical` / `High` / `Medium` / `Low` / `Nit` に分類する。
+- 「対応必須」と「任意改善」を分ける。
+- 既存の `/fugu` / `/cursor` と併用した場合は、一致した指摘を高確度として扱う。
+
+## 注意
+
+- このスキルはレビュー専用。実装修正はユーザーが依頼した場合だけ行う。
+- `Codex -p --permission-mode ...` は Claude Code 用オプションと混同しやすいので使わない。Codex CLI では `codex exec ... -s read-only` を使う。

--- a/pi/README.md
+++ b/pi/README.md
@@ -21,7 +21,7 @@ npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ## Link this config
 
 The dotfiles setup scripts link the tracked files into `~/.pi/agent` without
-touching `auth.json`:
+touching `auth.json`. `pi/agent/AGENTS.md` is Pi's global context file:
 
 ```bash
 ./scripts/build_env/setup_fish.sh
@@ -95,6 +95,16 @@ Reload after editing extensions:
 
 ## Skills
 
-Do not duplicate shared skills here. Pi automatically discovers
-`~/.agents/skills/`, so Firecrawl and other shared agent skills are loaded from
-the existing agents skill directory.
+Do not duplicate shared skills under `pi/agent/skills/`. Pi automatically
+discovers `~/.agents/skills/`, so Firecrawl and other shared agent skills are
+loaded from the existing agents skill directory.
+
+Some routing-critical skills are tracked in this repository for reproducibility:
+
+- `.agents/skills/cmux*`
+- `claude/skills/claude-review`
+- `codex/skills/codex-review`
+
+The setup scripts link matching `~/.agents/skills/*` paths back to those tracked
+directories. Keeping separate real copies in both places causes Pi skill-collision
+warnings.

--- a/pi/agent/AGENTS.md
+++ b/pi/agent/AGENTS.md
@@ -1,0 +1,11 @@
+# Pi Global Agent Instructions
+
+This file provides global instructions for Pi Coding Agent sessions.
+
+## AI Agent Routing
+
+- **Implementation**: Use the `cursor-impl` skill (`/skill:cursor-impl` in Pi) to delegate actively to Cursor Agent CLI `composer-2.5`. Pi prepares the implementation prompt and validates the resulting diff, lint, and tests. Only trivial few-line edits may be done directly.
+- **Web research**: Use the `firecrawl` skill (`/skill:firecrawl`) for general web search, scraping, URL fetches, docs crawling, and browser interaction. Use `firecrawl-agent` (`/skill:firecrawl-agent`) when structured JSON extraction or autonomous multi-page extraction is needed.
+- **Web research double-check**: Use `cross-research` (`/skill:cross-research`) for important research that needs verification; it runs Firecrawl and `agy` (Antigravity CLI, successor to Gemini CLI) in parallel. Use `antigravity-research` (`/skill:antigravity-research`) only for agy-only broad summaries where facts are not treated as confirmed.
+- **Review**: Use `cursor` or `fugu` (`/skill:cursor`, `/skill:fugu`) for Cursor Agent CLI `composer-2.5` + Codex/Fugu parallel review, `codex-review` (`/skill:codex-review`) for Codex review, and `claude-review` (`/skill:claude-review`) for Claude Opus review; compare findings before acting.
+- **MCP integrations**: Use Claude Sonnet for MCP-connected workflows, especially Slack and Sentry. Sentry issue workspace flow is covered by `jj-workspace` (`/skill:jj-workspace`); use a dedicated MCP delegation skill when available.

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -18,7 +18,7 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
-          "contextWindow": 128000,
+          "contextWindow": 1000000,
           "maxTokens": 32768
         },
         {
@@ -34,7 +34,7 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
-          "contextWindow": 128000,
+          "contextWindow": 1000000,
           "maxTokens": 32768
         }
       ]

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -21,5 +21,6 @@
   },
   "extensions": [
     "extensions/*.ts"
-  ]
+  ],
+  "lastChangelogVersion": "0.80.2"
 }

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -139,6 +139,26 @@ ln -sf ${BASE_DIR}/antigravity/skills/context-loader ~/.gemini/antigravity-cli/s
 # Pi Coding Agent
 # auth.json は秘密情報/OAuth を含むためリンクしない。
 mkdir -p ~/.pi/agent
+ln -sf ${BASE_DIR}/pi/agent/AGENTS.md ~/.pi/agent/AGENTS.md
 ln -sf ${BASE_DIR}/pi/agent/settings.json ~/.pi/agent/settings.json
 ln -sf ${BASE_DIR}/pi/agent/models.json ~/.pi/agent/models.json
 ln -sfn ${BASE_DIR}/pi/agent/extensions ~/.pi/agent/extensions
+
+# Shared agent skills
+# Keep selected skill sources tracked in this repository and expose them globally.
+mkdir -p ~/.agents/skills ~/.agents/skill-backups
+for SKILL in ${BASE_DIR}/.agents/skills/cmux*(N/) ${BASE_DIR}/claude/skills/claude-review(N/) ${BASE_DIR}/codex/skills/codex-review(N/); do
+  [ -f "${SKILL}/SKILL.md" ] || continue
+  NAME=$(basename "${SKILL}")
+  DEST="$HOME/.agents/skills/${NAME}"
+  if [ -L "${DEST}" ]; then
+    rm "${DEST}"
+  elif [ -e "${DEST}" ]; then
+    if diff -qr "${SKILL}" "${DEST}" >/dev/null 2>&1; then
+      rm -rf "${DEST}"
+    else
+      mv "${DEST}" "$HOME/.agents/skill-backups/${NAME}.backup-$(date +%Y%m%d%H%M%S)"
+    fi
+  fi
+  ln -sfn "${SKILL}" "${DEST}"
+done

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -190,9 +190,45 @@ set PI_AGENT_DIR ~/.pi/agent
 if not test -d $PI_AGENT_DIR
     mkdir -p $PI_AGENT_DIR
 end
+create_symlink $BASE_DIR/pi/agent/AGENTS.md $PI_AGENT_DIR/AGENTS.md "Pi global instructions"
 create_symlink $BASE_DIR/pi/agent/settings.json $PI_AGENT_DIR/settings.json "Pi settings"
 create_symlink $BASE_DIR/pi/agent/models.json $PI_AGENT_DIR/models.json "Pi custom models"
 create_symlink $BASE_DIR/pi/agent/extensions $PI_AGENT_DIR/extensions "Pi extensions"
+
+echo ""
+echo "🤖 Setting up shared agent skills..."
+set AGENTS_SKILL_DIR ~/.agents/skills
+set AGENTS_SKILL_BACKUP_DIR ~/.agents/skill-backups
+if not test -d $AGENTS_SKILL_DIR
+    mkdir -p $AGENTS_SKILL_DIR
+end
+if not test -d $AGENTS_SKILL_BACKUP_DIR
+    mkdir -p $AGENTS_SKILL_BACKUP_DIR
+end
+set SHARED_AGENT_SKILLS $BASE_DIR/.agents/skills/cmux* $BASE_DIR/claude/skills/claude-review $BASE_DIR/codex/skills/codex-review
+for SKILL in $SHARED_AGENT_SKILLS
+    if not test -f $SKILL/SKILL.md
+        continue
+    end
+    set NAME (basename $SKILL)
+    set DEST $AGENTS_SKILL_DIR/$NAME
+    if test -L $DEST
+        rm $DEST
+    else if test -e $DEST
+        if diff -qr $SKILL $DEST >/dev/null 2>&1
+            rm -rf $DEST
+        else
+            set BACKUP "$AGENTS_SKILL_BACKUP_DIR/$NAME.backup-"(date +%Y%m%d%H%M%S)
+            print_warning "Backing up existing agent skill: $DEST -> $BACKUP"
+            mv $DEST $BACKUP
+        end
+    end
+    if ln -sfn $SKILL $DEST
+        print_success "Linked agent skill: $NAME"
+    else
+        print_error "Failed to link agent skill: $DEST"
+    end
+end
 
 echo ""
 


### PR DESCRIPTION
## 概要

Pi Coding Agent 用の設定を追加します。

- **`pi/agent/AGENTS.md`**: Pi のグローバルコンテキストファイルを新規追加。AI エージェントのルーティング方針（実装は cursor-impl、Web 調査は firecrawl / cross-research、レビューは cursor/fugu/codex-review/claude-review、MCP は Claude Sonnet）を記載。
- **`scripts/build_env/setup_fish.sh` / `create_symlink.sh`**: 
  - `AGENTS.md` を `~/.pi/agent/AGENTS.md` に symlink。
  - routing-critical な共有スキル（`.agents/skills/cmux*`, `claude/skills/claude-review`, `codex/skills/codex-review`）を `~/.agents/skills/` に symlink。既存の実体ディレクトリはバックアップしてから貼り替えることで、Pi の skill-collision 警告を回避。
- **`codex/skills/codex-review/SKILL.md`**: Codex CLI を headless / read-only で起動するコードレビュー用スキルを追加。
- **`pi/agent/models.json`**: `contextWindow` を 1,000,000 に更新。
- **`pi/agent/settings.json`**: `lastChangelogVersion` を記録。
- **`pi/README.md`**: AGENTS.md と tracked skills の説明を追記。

## 補足

- 直前にマージ済みの #37 を base に取り込んだ上での追従変更です。
- 秘密情報（`pi/agent/auth.json`）と生成物（`pi/agent/sessions/`）は #37 で追加された `.gitignore` に従い追跡対象外。本 PR の差分には含まれません。

## 確認したこと

- `pi/agent/models.json` / `settings.json` の JSON 妥当性
- `setup_fish.sh` の fish 構文チェック（`fish -n`）
- `create_symlink.sh` の zsh 構文チェック（`zsh -n`）
- 参照している skill ディレクトリが実在すること
- 差分に秘密情報が含まれないこと