### PR TITLE
chore(pi): improve agent tooling configuration

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -22,6 +22,7 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "model": "claude-fable-5[1m]",
   "hooks": {
     "PreToolUse": [
       {
@@ -116,6 +117,5 @@
   },
   "effortLevel": "high",
   "skipDangerousModePermissionPrompt": true,
-  "remoteControlAtStartup": true,
-  "model": "claude-opus-4-6[1m]"
+  "remoteControlAtStartup": true
 }

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -25,6 +25,9 @@ trust_level = "trusted"
 [projects."/Users/roy/ghq/github.com/zero-color/agf-mall-shopify-theme"]
 trust_level = "trusted"
 
+[projects."/Users/roy/ghq/github.com/zero-color/crm-sentry-7588951588"]
+trust_level = "trusted"
+
 [features]
 rmcp_client = true
 image_generation = false

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -47,7 +47,15 @@
     "grpcurl@latest",
     "temporal-cli@latest",
     "bitwarden-cli@latest",
-    "socat@latest"
+    "socat@latest",
+    "ast-grep@latest",
+    "sd@latest",
+    "shellcheck@latest",
+    "shfmt@latest",
+    "taplo@latest",
+    "stylua@latest",
+    "hyperfine@latest",
+    "just@latest"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",

--- a/pi/agent/AGENTS.md
+++ b/pi/agent/AGENTS.md
@@ -2,6 +2,20 @@
 
 This file provides global instructions for Pi Coding Agent sessions.
 
+## Tool Preferences
+
+- Prefer `fd` over `find` for file and directory discovery. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Use `find` only when POSIX-specific behavior is required or `fd` is unavailable.
+- Prefer `rg` over recursive `grep` for text/code search.
+- Prefer `jq` and `yq` for JSON/YAML inspection and transformation.
+- Prefer `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
+- Prefer `sd` for simple literal/regex replacements in shell workflows; use precise edit tools for small source-file edits.
+- Prefer `taplo` for TOML formatting and validation.
+- Prefer `stylua` for Lua formatting.
+- Prefer `shellcheck` and `shfmt` for shell script validation and formatting.
+- Prefer `hyperfine` when comparing command performance.
+- Prefer `just` when a project provides a `justfile`/`Justfile` for common tasks.
+- Prefer non-interactive, machine-readable commands in automated agent workflows; avoid interactive tools such as `fzf` unless explicitly requested.
+
 ## AI Agent Routing
 
 - **Implementation**: Use the `cursor-impl` skill (`/skill:cursor-impl` in Pi) to delegate actively to Cursor Agent CLI `composer-2.5`. Pi prepares the implementation prompt and validates the resulting diff, lint, and tests. Only trivial few-line edits may be done directly.

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -22,5 +22,5 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.80.2"
+  "lastChangelogVersion": "0.80.3"
 }


### PR DESCRIPTION
## Summary
- Add agent-oriented CLI tools to devbox global packages
- Document Pi tool preferences for non-interactive agent workflows
- Update Pi agent settings changelog state and formatting
- Include existing Claude/Codex agent configuration updates from the working copy

## Validation
- `jq empty claude/settings.json pi/agent/settings.json devbox/devbox.json`
- `python3` TOML parse for `codex/config.toml`
