### PR TITLE
chore(pi): remove unused agent tooling

### DIFF
--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -52,10 +52,7 @@
     "sd@latest",
     "shellcheck@latest",
     "shfmt@latest",
-    "taplo@latest",
-    "stylua@latest",
-    "hyperfine@latest",
-    "just@latest"
+    "taplo@latest"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",

--- a/pi/agent/AGENTS.md
+++ b/pi/agent/AGENTS.md
@@ -10,10 +10,7 @@ This file provides global instructions for Pi Coding Agent sessions.
 - Prefer `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
 - Prefer `sd` for simple literal/regex replacements in shell workflows; use precise edit tools for small source-file edits.
 - Prefer `taplo` for TOML formatting and validation.
-- Prefer `stylua` for Lua formatting.
 - Prefer `shellcheck` and `shfmt` for shell script validation and formatting.
-- Prefer `hyperfine` when comparing command performance.
-- Prefer `just` when a project provides a `justfile`/`Justfile` for common tasks.
 - Prefer non-interactive, machine-readable commands in automated agent workflows; avoid interactive tools such as `fzf` unless explicitly requested.
 
 ## AI Agent Routing


### PR DESCRIPTION
## Summary
- Remove `just` from global devbox packages and Pi tool preferences because no Justfile is present
- Remove `stylua` from global devbox packages and Pi tool preferences because Lua formatting is not broadly needed for Pi workflows
- Remove `hyperfine` from global devbox packages and Pi tool preferences because command benchmarking is not a common Pi workflow

## Validation
- `jq empty devbox/devbox.json pi/agent/settings.json claude/settings.json`
- Python TOML parse for `codex/config.toml`
