### PR TITLE
chore(pi): clamp OpenAI output token minimum

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,5 +1,5 @@
-model = "gpt-5.3-codex"
-model_reasoning_effort = "high"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 model_provider = "openai"
 personality = "pragmatic"
 project_doc_fallback_filenames = [ "CLAUDE.md" ]
@@ -46,3 +46,11 @@ ENABLE_LSP_TOOL = "true"
 CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1"
 CLAUDE_CODE_NO_FLICKER = "1"
 USE_BUILTIN_RIPGREP = "0"
+
+[hooks.state]
+
+[hooks.state."/Users/roy/.codex/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:24040b144c1aa832f157332887d96e444f92ac77deec3fa9667c38e8d47e471f"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 1

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -64,7 +64,7 @@
   "shell": {
     "init_hook": [],
     "scripts": {
-      "setup-npm": "npm install -g neovim typescript @typescript/native-preview @openai/codex cf firecrawl-cli && npm install -g --ignore-scripts --min-release-age=0 @earendil-works/pi-coding-agent"
+      "setup-npm": "npm install -g neovim typescript @typescript/native-preview @openai/codex cf firecrawl-cli && npm install -g --ignore-scripts --min-release-age=0 @earendil-works/pi-coding-agent && bash $(ghq root)/github.com/RoyMcCrain/dotsfile/scripts/build_env/patch_pi_min_output_tokens.sh"
     }
   }
 }

--- a/pi/README.md
+++ b/pi/README.md
@@ -16,7 +16,13 @@ Manual install:
 
 ```bash
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+./scripts/build_env/patch_pi_min_output_tokens.sh
 ```
+
+The patch avoids OpenAI Responses API errors where Pi sends
+`max_output_tokens < 16` during a near-full compaction request. Restart Pi after
+patching; `/reload` only reloads extensions and does not reload Pi's core
+`node_modules`.
 
 ## Link this config
 
@@ -83,9 +89,10 @@ literal API key or an environment reference such as `$SAKANA_API_KEY`.
 
 Configured by `settings.json` via `extensions/*.ts`.
 
-| Extension         | Purpose                                                              |
-| ----------------- | -------------------------------------------------------------------- |
-| `local-openai.ts` | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
+| Extension                       | Purpose                                                              |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `local-openai.ts`               | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
+| `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
 
 Reload after editing extensions:
 

--- a/pi/agent/extensions/clamp-openai-output-tokens.ts
+++ b/pi/agent/extensions/clamp-openai-output-tokens.ts
@@ -1,0 +1,23 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const MIN_OPENAI_OUTPUT_TOKENS = 16;
+
+const isObjectPayload = (payload: unknown): payload is Record<string, unknown> => {
+  return typeof payload === "object" && payload !== null && !Array.isArray(payload);
+};
+
+export default function clampOpenAIOutputTokens(pi: ExtensionAPI) {
+  pi.on("before_provider_request", (event) => {
+    if (!isObjectPayload(event.payload)) return;
+
+    const maxOutputTokens = event.payload.max_output_tokens;
+    if (typeof maxOutputTokens !== "number") return;
+    if (!Number.isFinite(maxOutputTokens)) return;
+    if (maxOutputTokens >= MIN_OPENAI_OUTPUT_TOKENS) return;
+
+    return {
+      ...event.payload,
+      max_output_tokens: MIN_OPENAI_OUTPUT_TOKENS,
+    };
+  });
+}

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -7,8 +7,8 @@
   "enableInstallTelemetry": false,
   "compaction": {
     "enabled": true,
-    "reserveTokens": 16384,
-    "keepRecentTokens": 20000
+    "reserveTokens": 32768,
+    "keepRecentTokens": 8000
   },
   "retry": {
     "enabled": true,

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -149,6 +149,11 @@ ln -sf ${BASE_DIR}/pi/agent/AGENTS.md ~/.pi/agent/AGENTS.md
 ln -sf ${BASE_DIR}/pi/agent/settings.json ~/.pi/agent/settings.json
 ln -sf ${BASE_DIR}/pi/agent/models.json ~/.pi/agent/models.json
 ln -sfn ${BASE_DIR}/pi/agent/extensions ~/.pi/agent/extensions
+if command -v npm >/dev/null 2>&1; then
+  bash "${BASE_DIR}/scripts/build_env/patch_pi_min_output_tokens.sh"
+else
+  echo "skip Pi runtime patch (npm not found)"
+fi
 
 # Shared agent skills
 # Keep selected skill sources tracked in this repository and expose them globally.

--- a/scripts/build_env/patch_pi_min_output_tokens.sh
+++ b/scripts/build_env/patch_pi_min_output_tokens.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PI_SIMPLE_OPTIONS="$(npm root -g)/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/api/simple-options.js"
+
+if [[ ! -f "$PI_SIMPLE_OPTIONS" ]]; then
+	echo "Pi simple-options.js not found: $PI_SIMPLE_OPTIONS" >&2
+	exit 1
+fi
+
+node - "$PI_SIMPLE_OPTIONS" <<'NODE'
+const fs = require("node:fs");
+
+const file = process.argv[2];
+const source = fs.readFileSync(file, "utf8");
+const patched = source.replace(
+  /const MIN_MAX_TOKENS = \d+;/,
+  "const MIN_MAX_TOKENS = 16;",
+);
+
+if (patched === source && !source.includes("const MIN_MAX_TOKENS = 16;")) {
+  throw new Error(`MIN_MAX_TOKENS declaration not found in ${file}`);
+}
+
+if (patched !== source) {
+  fs.writeFileSync(file, patched, "utf8");
+}
+
+console.log(`Patched Pi minimum max tokens: ${file}`);
+NODE

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -195,6 +195,11 @@ create_symlink $BASE_DIR/pi/agent/APPEND_SYSTEM.md $PI_AGENT_DIR/APPEND_SYSTEM.m
 create_symlink $BASE_DIR/pi/agent/settings.json $PI_AGENT_DIR/settings.json "Pi settings"
 create_symlink $BASE_DIR/pi/agent/models.json $PI_AGENT_DIR/models.json "Pi custom models"
 create_symlink $BASE_DIR/pi/agent/extensions $PI_AGENT_DIR/extensions "Pi extensions"
+if command -q npm
+    bash $BASE_DIR/scripts/build_env/patch_pi_min_output_tokens.sh
+else
+    print_warning "Skipped Pi runtime patch (npm not found)"
+end
 
 echo ""
 echo "🤖 Setting up shared agent skills..."


### PR DESCRIPTION
## Summary
- add a Pi extension that clamps OpenAI-style `max_output_tokens` to the API minimum of 16
- add a setup patch script for Pi's runtime minimum token constant and run it from setup scripts
- tune Pi compaction defaults and document the install/patch flow
- update Codex default model settings

## Validation
- `zsh -n scripts/build_env/create_symlink.sh`
- `bash -n scripts/build_env/patch_pi_min_output_tokens.sh`
- `fish --no-config -n scripts/build_env/setup_fish.sh`
- `python3 -m json.tool pi/agent/settings.json`
- `python3 -m json.tool devbox/devbox.json`
