### PR TITLE
chore(pi): add token-saving agent controls

### DIFF
--- a/.agents/skills/cheap-pr/SKILL.md
+++ b/.agents/skills/cheap-pr/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: cheap-pr
+description: PR作成を安価モデル優先で行う。ユーザーが「PRだして」「PR出して」「PR作って」「pull requestを作成」「プルリク作成」など、PRを開く/提出する依頼をしたときに使う。
+metadata:
+  target_agent: Codex
+---
+
+# /cheap-pr
+
+PR作成を、余計な高価モデル呼び出しを避けて実行するスキル。
+
+## モデル方針
+
+- PR作成だけなら、追加の高価モデル（`fugu-ultra` / Opus / Cursor など）へ委譲しない。
+- Pi では可能なら `sakana-ai-console/fugu` を使う。
+  - `cheap-pr-model.ts` 拡張が有効なら、PR作成依頼時に自動で `fugu` へ切り替わる。
+  - 既に高価モデルでターンが始まっている場合は、そのターンでは CLI と既存情報中心で進め、追加の LLM サブタスクを増やさない。
+- レビューや長いPR説明生成が必要な場合だけ、ユーザーに確認してから追加モデルを使う。
+
+## 実行手順
+
+1. 状態確認
+   - `.jj` がある場合は `git` ではなく `jj` を使う。
+   - `jj status` と `jj diff` で差分を確認する。
+2. 最小検証
+   - 変更内容に応じて軽い検証だけ実行する。
+   - 大きなテストや外部レビューは、ユーザーが明示しない限り省く。
+3. リビジョン説明
+   - `JJ_EDITOR=true jj describe -m "..."` で短い説明を付ける。
+4. bookmark
+   - ユーザー指定がなければ変更内容から短い bookmark 名を作る。
+   - 例: `chore/pi-token-controls`
+   - `jj bookmark create <name> -r @` または既存 bookmark なら `jj bookmark set <name> -r @` を使う。
+5. push
+   - ユーザーがPR作成を明示している場合のみ `jj git push --bookmark <name>` する。
+   - force-push は明示依頼がある場合だけ行う。
+6. PR作成
+   - `gh pr create --base main --head <name> --title "..." --body "..."` を使う。
+   - PR本文は簡潔にする。
+
+## PR本文テンプレート
+
+```markdown
+## Summary
+- ...
+
+## Verification
+- ...
+```
+
+## 注意
+
+- 秘密 env ファイル（`.env`, `.env.local`, `.env.*.local`, `.envrc.local`）は読まない。
+- PR作成は外部送信なので、ユーザーが「PRだして」等で明示したときだけ実行する。
+- merge / branch削除 / bookmark削除 / force-push は、ユーザーが明示したときだけ実行する。

--- a/pi/README.md
+++ b/pi/README.md
@@ -93,6 +93,8 @@ Configured by `settings.json` via `extensions/*.ts`.
 | ------------------------------- | -------------------------------------------------------------------- |
 | `local-openai.ts`               | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
+| `cheap-pr-model.ts`             | Switch PR creation requests to `sakana-ai-console/fugu`.             |
+| `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
 
 Reload after editing extensions:
 
@@ -109,6 +111,7 @@ loaded from the existing agents skill directory.
 Some routing-critical skills are tracked in this repository for reproducibility:
 
 - `.agents/skills/cmux*`
+- `.agents/skills/cheap-pr`
 - `.agents/skills/cursor-review`
 - `.agents/skills/fugu-review`
 - `.agents/skills/parallel-review`

--- a/pi/agent/extensions/cheap-pr-model.ts
+++ b/pi/agent/extensions/cheap-pr-model.ts
@@ -1,0 +1,50 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const CHEAP_PROVIDER = "sakana-ai-console";
+const CHEAP_MODEL = "fugu";
+
+const CREATE_PR_PATTERNS = [
+  /\bPR\b.*(?:だして|出して|出す|作って|作成|作る|open|create)/iu,
+  /(?:だして|出して|出す|作って|作成|作る|open|create).*\bPR\b/iu,
+  /(?:pull request|プルリク).*(?:だして|出して|出す|作って|作成|作る|open|create)/iu,
+  /(?:だして|出して|出す|作って|作成|作る|open|create).*(?:pull request|プルリク)/iu,
+];
+
+const NON_CREATE_PR_PATTERN =
+  /(?:レビュー|review|確認|見て|コメント|comment|address|対応|merge|マージ)/iu;
+
+const isCreatePrRequest = (text: string) => {
+  if (NON_CREATE_PR_PATTERN.test(text)) return false;
+
+  return CREATE_PR_PATTERNS.some((pattern) => pattern.test(text));
+};
+
+export default function cheapPrModel(pi: ExtensionAPI) {
+  pi.on("input", async (event, ctx) => {
+    if (event.source === "extension") return;
+    if (!isCreatePrRequest(event.text)) return;
+    if (ctx.model.provider === CHEAP_PROVIDER && ctx.model.id === CHEAP_MODEL) {
+      return;
+    }
+
+    const model = ctx.modelRegistry.find(CHEAP_PROVIDER, CHEAP_MODEL);
+    if (!model) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `Cheap PR model not found: ${CHEAP_PROVIDER}/${CHEAP_MODEL}`,
+          "warning",
+        );
+      }
+      return;
+    }
+
+    const switched = await pi.setModel(model);
+    if (ctx.hasUI) {
+      const level = switched ? "info" : "warning";
+      const message = switched
+        ? `PR作成のため安価モデルに切替: ${CHEAP_PROVIDER}/${CHEAP_MODEL}`
+        : `PR作成用モデルに切替できませんでした: ${CHEAP_PROVIDER}/${CHEAP_MODEL}`;
+      ctx.ui.notify(message, level);
+    }
+  });
+}

--- a/pi/agent/extensions/save-compaction-log.ts
+++ b/pi/agent/extensions/save-compaction-log.ts
@@ -1,0 +1,59 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createHash } from "node:crypto";
+import { appendFile, chmod, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+const LOG_DIR = join(homedir(), ".pi", "agent", "compaction-logs");
+
+const safeProjectLogName = (cwd: string) => {
+  const base = basename(cwd) || "project";
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80) ||
+    "project";
+  const hash = createHash("sha256").update(cwd).digest("hex").slice(0, 12);
+
+  return `${safeBase}-${hash}.md`;
+};
+
+const errorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+
+  return String(error);
+};
+
+export default function saveCompactionLog(pi: ExtensionAPI) {
+  pi.on("session_compact", async (event, ctx) => {
+    const entry = event.compactionEntry;
+    const logPath = join(LOG_DIR, safeProjectLogName(ctx.cwd));
+    const summary = entry.summary.trimEnd();
+    const content = [
+      `## ${new Date(entry.timestamp).toISOString()} (${event.reason})`,
+      "",
+      `- cwd: ${ctx.cwd}`,
+      `- firstKeptEntryId: ${entry.firstKeptEntryId}`,
+      `- tokensBefore: ${entry.tokensBefore}`,
+      "",
+      summary,
+      "",
+      "---",
+      "",
+    ].join("\n");
+
+    try {
+      await mkdir(LOG_DIR, { recursive: true });
+      await appendFile(logPath, content, { encoding: "utf8", mode: 0o600 });
+      await chmod(logPath, 0o600).catch(() => {});
+
+      if (ctx.hasUI) {
+        ctx.ui.notify(`Compaction log saved: ${logPath}`, "info");
+      }
+    } catch (error) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `Failed to save compaction log: ${errorMessage(error)}`,
+          "error",
+        );
+      }
+    }
+  });
+}

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -34,8 +34,8 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
-          "contextWindow": 1000000,
-          "maxTokens": 32768
+          "contextWindow": 200000,
+          "maxTokens": 8192
         }
       ]
     }

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -166,7 +166,7 @@ for OLD_SKILL in cursor fugu; do
     mv "${OLD_DEST}" "$HOME/.agents/skill-backups/${OLD_SKILL}.backup-$(date +%Y%m%d%H%M%S)"
   fi
 done
-for SKILL in ${BASE_DIR}/.agents/skills/cmux*(N/) ${BASE_DIR}/.agents/skills/cursor-review(N/) ${BASE_DIR}/.agents/skills/fugu-review(N/) ${BASE_DIR}/.agents/skills/parallel-review(N/) ${BASE_DIR}/claude/skills/claude-review(N/) ${BASE_DIR}/codex/skills/codex-review(N/); do
+for SKILL in ${BASE_DIR}/.agents/skills/cmux*(N/) ${BASE_DIR}/.agents/skills/cheap-pr(N/) ${BASE_DIR}/.agents/skills/cursor-review(N/) ${BASE_DIR}/.agents/skills/fugu-review(N/) ${BASE_DIR}/.agents/skills/parallel-review(N/) ${BASE_DIR}/claude/skills/claude-review(N/) ${BASE_DIR}/codex/skills/codex-review(N/); do
   [ -f "${SKILL}/SKILL.md" ] || continue
   NAME=$(basename "${SKILL}")
   DEST="$HOME/.agents/skills/${NAME}"

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -222,7 +222,7 @@ for OLD_NAME in cursor fugu
         mv $OLD_DEST $BACKUP
     end
 end
-set SHARED_AGENT_SKILLS $BASE_DIR/.agents/skills/cmux* $BASE_DIR/.agents/skills/cursor-review $BASE_DIR/.agents/skills/fugu-review $BASE_DIR/.agents/skills/parallel-review $BASE_DIR/claude/skills/claude-review $BASE_DIR/codex/skills/codex-review
+set SHARED_AGENT_SKILLS $BASE_DIR/.agents/skills/cmux* $BASE_DIR/.agents/skills/cheap-pr $BASE_DIR/.agents/skills/cursor-review $BASE_DIR/.agents/skills/fugu-review $BASE_DIR/.agents/skills/parallel-review $BASE_DIR/claude/skills/claude-review $BASE_DIR/codex/skills/codex-review
 for SKILL in $SHARED_AGENT_SKILLS
     if not test -f $SKILL/SKILL.md
         continue


### PR DESCRIPTION
## Summary
- Reduce `fugu-ultra` Pi config to a 200K context window and 8.2K max output tokens so auto-compaction happens earlier and long accidental outputs are capped.
- Add a compaction log extension that appends compact summaries to `~/.pi/agent/compaction-logs/`.
- Add a cheap PR workflow skill and Pi extension that switches PR creation requests to `sakana-ai-console/fugu`.
- Include the new shared skill in setup symlink scripts and document the new Pi extensions.

## Verification
- `pi --list-models`
- `fish -n scripts/build_env/setup_fish.sh`
- `zsh -n scripts/build_env/create_symlink.sh`
- `deno fmt --check pi/agent/extensions/cheap-pr-model.ts pi/agent/extensions/save-compaction-log.ts`
