### PR TITLE
feat(pi): enable image input for Sakana Fugu models

### DIFF
--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -10,7 +10,8 @@
           "name": "Sakana Fugu",
           "reasoning": false,
           "input": [
-            "text"
+            "text",
+            "image"
           ],
           "cost": {
             "input": 0,
@@ -26,7 +27,8 @@
           "name": "Sakana Fugu Ultra",
           "reasoning": false,
           "input": [
-            "text"
+            "text",
+            "image"
           ],
           "cost": {
             "input": 0,


### PR DESCRIPTION
## Summary
- Add `"image"` to the `input` array for `sakana-ai-console/fugu` and `fugu-ultra` in `pi/agent/models.json` so Pi accepts screenshots as image attachments
- Confirmed both model slugs support vision via Sakana's Codex model catalog JSON (`input_modalities: ["text", "image"]`)
- Video input is intentionally out of scope: Pi's model schema only supports `"text"`/`"image"`, no `"video"` type

## Test plan
- [x] `models.json` validated as valid JSON
- [ ] Open `/model` in Pi and confirm `fugu`/`fugu-ultra` accept an attached screenshot