### PR TITLE
feat(pi): lazy-load monorepo AGENTS.md / CLAUDE.md via extension

### DIFF
--- a/pi/agent/extensions/monorepo-claude-md.ts
+++ b/pi/agent/extensions/monorepo-claude-md.ts
@@ -1,16 +1,15 @@
 /**
- * Monorepo CLAUDE.md lazy loader
+ * モノレポ CLAUDE.md 遅延ローダー
  *
- * Pi's built-in context loading only reads CLAUDE.md/AGENTS.md from the cwd and
- * its parent directories. In a monorepo where each package has its own
- * CLAUDE.md, that misses everything in sibling subtrees.
+ * Pi の組み込みコンテキスト読み込みは、cwd とその親ディレクトリの
+ * CLAUDE.md/AGENTS.md しか読まない。各パッケージが自身の CLAUDE.md を持つ
+ * モノレポでは、別サブツリー（sibling subtree）の内容がすべて漏れてしまう。
  *
- * This extension loads those files lazily: when the agent touches a file via
- * read/edit/write, it walks up from that file to the repo root and appends the
- * CLAUDE.md of every ancestor directory (shared root conventions + local rules)
- * to the tool result. So working on the frontend loads only the frontend's
- * CLAUDE.md, and touching the backend later adds the backend's — you only pay
- * for the parts you actually use. Each file is injected at most once per session.
+ * この拡張はそれらを遅延ロードする: エージェントが read/edit/write でファイルを
+ * 触ると、そのファイルから repo root まで上に辿り、各祖先ディレクトリの CLAUDE.md
+ * （共通の root 規約 + ローカル規約）を tool result に追記する。フロントを触れば
+ * フロントの CLAUDE.md だけが載り、あとでバックを触ればバックの分が追加される
+ * ——実際に使う部分のぶんだけコストを払う。各ファイルはセッション中に最大1回だけ注入する。
  */
 
 import * as fs from "node:fs";
@@ -40,7 +39,7 @@ const walkUpFrom = (startDir: string, visit: (dir: string) => boolean | void) =>
   }
 };
 
-// Walk up for a VCS marker to bound the upward search; fall back to cwd.
+// VCS マーカーを上方向に探して探索範囲を区切る。見つからなければ cwd を使う。
 const findRepoRoot = (start: string) => {
   let repoRoot = start;
   walkUpFrom(start, (dir) => {
@@ -52,9 +51,9 @@ const findRepoRoot = (start: string) => {
   return repoRoot;
 };
 
-// Ancestor CLAUDE.md paths from repo root down to the file's directory.
-// Root-first so shared conventions precede local overrides.
-// Skips directories on the cwd→root chain (already loaded by Pi's built-in loader).
+// repo root からファイルのディレクトリまでの、祖先 CLAUDE.md のパス。
+// root-first（共通規約がローカル上書きより先）で返す。
+// cwd→root チェーン上のディレクトリはスキップする（Pi の組み込みローダーが既に読むため）。
 const ancestorContextFiles = (absFile: string, repoRoot: string, cwd: string) => {
   if (!isInside(repoRoot, absFile)) return [];
 
@@ -127,7 +126,7 @@ export default function monorepoClaudeMd(pi: ExtensionAPI) {
           `--- Directory guidance from ${relPath} ---\n${content}\n--- end guidance (${relPath}) ---`,
         );
       } catch {
-        // Unreadable file: skip silently, keep the tool result intact.
+        // 読めないファイルは黙ってスキップし、tool result はそのまま保つ。
       }
     }
 

--- a/pi/agent/extensions/monorepo-claude-md.ts
+++ b/pi/agent/extensions/monorepo-claude-md.ts
@@ -1,15 +1,18 @@
 /**
- * モノレポ CLAUDE.md 遅延ローダー
+ * モノレポ AGENTS.md / CLAUDE.md 遅延ローダー
  *
  * Pi の組み込みコンテキスト読み込みは、cwd とその親ディレクトリの
- * CLAUDE.md/AGENTS.md しか読まない。各パッケージが自身の CLAUDE.md を持つ
- * モノレポでは、別サブツリー（sibling subtree）の内容がすべて漏れてしまう。
+ * AGENTS.md/CLAUDE.md しか読まない。各パッケージが自身のコンテキストファイルを
+ * 持つモノレポでは、別サブツリー（sibling subtree）の内容がすべて漏れてしまう。
  *
  * この拡張はそれらを遅延ロードする: エージェントが read/edit/write でファイルを
- * 触ると、そのファイルから repo root まで上に辿り、各祖先ディレクトリの CLAUDE.md
- * （共通の root 規約 + ローカル規約）を tool result に追記する。フロントを触れば
- * フロントの CLAUDE.md だけが載り、あとでバックを触ればバックの分が追加される
+ * 触ると、そのファイルから repo root まで上に辿り、各祖先ディレクトリのコンテキスト
+ * ファイル（共通の root 規約 + ローカル規約）を tool result に追記する。フロントを
+ * 触ればフロントのファイルだけが載り、あとでバックを触ればバックの分が追加される
  * ——実際に使う部分のぶんだけコストを払う。各ファイルはセッション中に最大1回だけ注入する。
+ *
+ * 1ディレクトリに両方ある場合は AGENTS.md を優先し、1ファイルだけ採用する
+ * （Pi 組み込みローダーおよび agents.md 規約と整合）。
  */
 
 import * as fs from "node:fs";
@@ -21,7 +24,8 @@ import {
   type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 
-const CONTEXT_FILE = "CLAUDE.md";
+// 1ディレクトリでの採用優先順（先頭が優先）。
+const CONTEXT_FILES = ["AGENTS.md", "CLAUDE.md"];
 const MAX_FILE_BYTES = 32 * 1024;
 
 const isInside = (from: string, to: string) => {
@@ -51,7 +55,7 @@ const findRepoRoot = (start: string) => {
   return repoRoot;
 };
 
-// repo root からファイルのディレクトリまでの、祖先 CLAUDE.md のパス。
+// repo root からファイルのディレクトリまでの、祖先コンテキストファイルのパス。
 // root-first（共通規約がローカル上書きより先）で返す。
 // cwd→root チェーン上のディレクトリはスキップする（Pi の組み込みローダーが既に読むため）。
 const ancestorContextFiles = (absFile: string, repoRoot: string, cwd: string) => {
@@ -60,8 +64,14 @@ const ancestorContextFiles = (absFile: string, repoRoot: string, cwd: string) =>
   const found: string[] = [];
   walkUpFrom(path.dirname(absFile), (dir) => {
     if (!isInside(dir, cwd)) {
-      const candidate = path.join(dir, CONTEXT_FILE);
-      if (fs.existsSync(candidate)) found.push(candidate);
+      // 1ディレクトリ1ファイルだけ（AGENTS.md 優先）。
+      for (const name of CONTEXT_FILES) {
+        const candidate = path.join(dir, name);
+        if (fs.existsSync(candidate)) {
+          found.push(candidate);
+          break;
+        }
+      }
     }
     return dir === repoRoot;
   });

--- a/pi/agent/extensions/monorepo-claude-md.ts
+++ b/pi/agent/extensions/monorepo-claude-md.ts
@@ -1,0 +1,140 @@
+/**
+ * Monorepo CLAUDE.md lazy loader
+ *
+ * Pi's built-in context loading only reads CLAUDE.md/AGENTS.md from the cwd and
+ * its parent directories. In a monorepo where each package has its own
+ * CLAUDE.md, that misses everything in sibling subtrees.
+ *
+ * This extension loads those files lazily: when the agent touches a file via
+ * read/edit/write, it walks up from that file to the repo root and appends the
+ * CLAUDE.md of every ancestor directory (shared root conventions + local rules)
+ * to the tool result. So working on the frontend loads only the frontend's
+ * CLAUDE.md, and touching the backend later adds the backend's — you only pay
+ * for the parts you actually use. Each file is injected at most once per session.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  isEditToolResult,
+  isReadToolResult,
+  isWriteToolResult,
+  type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+
+const CONTEXT_FILE = "CLAUDE.md";
+const MAX_FILE_BYTES = 32 * 1024;
+
+const isInside = (from: string, to: string) => {
+  const rel = path.relative(from, to);
+  return rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel);
+};
+
+const walkUpFrom = (startDir: string, visit: (dir: string) => boolean | void) => {
+  let dir = startDir;
+  while (true) {
+    if (visit(dir)) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+};
+
+// Walk up for a VCS marker to bound the upward search; fall back to cwd.
+const findRepoRoot = (start: string) => {
+  let repoRoot = start;
+  walkUpFrom(start, (dir) => {
+    if (fs.existsSync(path.join(dir, ".git")) || fs.existsSync(path.join(dir, ".jj"))) {
+      repoRoot = dir;
+      return true;
+    }
+  });
+  return repoRoot;
+};
+
+// Ancestor CLAUDE.md paths from repo root down to the file's directory.
+// Root-first so shared conventions precede local overrides.
+// Skips directories on the cwd→root chain (already loaded by Pi's built-in loader).
+const ancestorContextFiles = (absFile: string, repoRoot: string, cwd: string) => {
+  if (!isInside(repoRoot, absFile)) return [];
+
+  const found: string[] = [];
+  walkUpFrom(path.dirname(absFile), (dir) => {
+    if (!isInside(dir, cwd)) {
+      const candidate = path.join(dir, CONTEXT_FILE);
+      if (fs.existsSync(candidate)) found.push(candidate);
+    }
+    return dir === repoRoot;
+  });
+  return found.reverse();
+};
+
+const readContextContent = (file: string): string => {
+  const buf = fs.readFileSync(file);
+  if (buf.length > MAX_FILE_BYTES) {
+    return (
+      buf.subarray(0, MAX_FILE_BYTES).toString("utf8").trimEnd() +
+      "\n… (truncated, file exceeds 32KB)"
+    );
+  }
+  return buf.toString("utf8").trimEnd();
+};
+
+export default function monorepoClaudeMd(pi: ExtensionAPI) {
+  let repoRoot = "";
+  let realRepoRoot = "";
+  const injected = new Set<string>();
+
+  pi.on("session_start", async (_event, ctx) => {
+    repoRoot = findRepoRoot(ctx.cwd);
+    try {
+      realRepoRoot = fs.realpathSync(repoRoot);
+    } catch {
+      realRepoRoot = repoRoot;
+    }
+    injected.clear();
+  });
+
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.isError) return;
+
+    const rawPath =
+      isReadToolResult(event) || isEditToolResult(event) || isWriteToolResult(event)
+        ? event.input.path
+        : undefined;
+    if (typeof rawPath !== "string" || !rawPath) return;
+
+    const absFile = path.resolve(ctx.cwd, rawPath);
+    const blocks: string[] = [];
+
+    for (const file of ancestorContextFiles(absFile, repoRoot, ctx.cwd)) {
+      if (isReadToolResult(event) && path.resolve(file) === absFile) continue;
+
+      let realCandidate: string;
+      try {
+        realCandidate = fs.realpathSync(file);
+      } catch {
+        continue;
+      }
+      if (!isInside(realRepoRoot, realCandidate)) continue;
+      if (injected.has(realCandidate)) continue;
+
+      try {
+        const content = readContextContent(realCandidate);
+        injected.add(realCandidate);
+        const relPath = path.relative(repoRoot, file);
+        blocks.push(
+          `--- Directory guidance from ${relPath} ---\n${content}\n--- end guidance (${relPath}) ---`,
+        );
+      } catch {
+        // Unreadable file: skip silently, keep the tool result intact.
+      }
+    }
+
+    if (blocks.length === 0) return;
+
+    return {
+      content: [...event.content, { type: "text", text: `\n\n${blocks.join("\n\n")}` }],
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Add `pi/agent/extensions/monorepo-claude-md.ts`: a Pi user extension that lazily loads scattered `AGENTS.md` / `CLAUDE.md` context files in a monorepo.
- Pi's built-in loader only reads context files from cwd and its parents. This extension covers sibling subtrees: on `read`/`edit`/`write` tool results it walks from the touched file up to the repo root and appends each ancestor directory's context file (root-first, once per session). You only load guidance for the parts you actually touch (e.g. frontend work loads frontend rules, not backend).
- Per directory it picks a single file with **`AGENTS.md` taking priority over `CLAUDE.md`**, matching Pi's built-in loader and the agents.md convention (no double injection when both exist).

## Safeguards
- **Symlink escape guard**: resolves realpath and enforces containment within the real repo root before reading; dedup by real path.
- **32KB per-file cap** with a truncation notice (token-bomb protection).
- **No duplication** of the cwd→root chain already injected by Pi's built-in loader.
- **Ignores errored/invalid tool results** (`event.isError`, non-path tools).
- Correct repo-boundary check that doesn't misclassify names like `..generated/`.

## Notes
- Code comments are written in Japanese.
- AGENTS.md multi-placement was confirmed as actively supported/practiced across Codex, Cursor, Amp, Jules, and Gemini (agents.md convention; OpenAI's own repo ships ~88 AGENTS.md files), so covering it here is meaningful.

## Verification
- `tsc --noEmit --strict` against the installed Pi type definitions: TYPECHECK OK.
- Parallel review (Cursor + Codex) applied; High/Medium findings fixed and re-verified.
