### PR TITLE
chore(pi): widen fugu context window to 1M for auto-compaction

### DIFF
--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -19,7 +19,7 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
-          "contextWindow": 200000,
+          "contextWindow": 1000000,
           "maxTokens": 32768
         },
         {
@@ -36,7 +36,7 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
-          "contextWindow": 200000,
+          "contextWindow": 1000000,
           "maxTokens": 16384
         }
       ]


### PR DESCRIPTION
## Summary
- `pi/agent/models.json` の `fugu` / `fugu-ultra` の `contextWindow` を 200000 → 1000000 に拡大
- 200k だと自動コンパクト前にコンテキストが逼迫して作業が止まりがちだったため
- 出力上限 `maxTokens`（fugu=32768, fugu-ultra=16384）は週次クォータ保護のため据え置き

## Verification
- `jq empty` で models.json が valid JSON
- pi 本体の `ModelConfig.load()` で実ロード成功（TypeBox スキーマ検証通過）
- `contextWindow` / `maxTokens` は pi 内部で独立フィールドと確認 → 出力上限は不変
- 自動コンパクトは `settings.json` の `compaction.enabled:true` で有効、発火点は `1000000 - reserveTokens(32768) = 967232`
- 反映には pi 再起動が必要（`/reload` は extension のみ）