### PR TITLE
chore(pi): trigger auto-compaction at 300k tokens

### DIFF
--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -7,7 +7,7 @@
   "enableInstallTelemetry": false,
   "compaction": {
     "enabled": true,
-    "reserveTokens": 32768,
+    "reserveTokens": 700000,
     "keepRecentTokens": 8000
   },
   "retry": {


### PR DESCRIPTION
## Summary
- `pi/agent/settings.json` の `compaction.reserveTokens` を 32768 → 700000 に変更
- 自動コンパクトの発火点を `contextWindow - reserveTokens = 1000000 - 700000 = 300000`（≒300k）に設定
- 1M フルまで溜め込まず、300k で軽く畳んでコンテキストを保つのが狙い

## Verification
- `jq empty` で settings.json が valid JSON
- 発火条件 `contextTokens > contextWindow - reserveTokens`（compaction.js `shouldCompact`）で 300k 発火を確認
- `contextWindow`(1M) と overflow 検出は不変なので API 送信上限には影響なし
- `reserveTokens` は閾値計算のみに使われ、要約出力量は `model.maxTokens`(16384) 側で頭打ちのため副作用なし
- 反映には pi 再起動が必要（`/reload` は extension のみ）