### PR TITLE
chore(codex): bump model to gpt-5.6-terra

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.5"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 model_provider = "openai"
 personality = "pragmatic"


### PR DESCRIPTION
## Summary
- Update `codex/config.toml` model from `gpt-5.5` to `gpt-5.6-terra`

## Verification
- Config-only change; no functional testing required