### PR TITLE
feat(pi): restore previous model after cheap-pr switch

### DIFF
--- a/pi/agent/extensions/cheap-pr-model.ts
+++ b/pi/agent/extensions/cheap-pr-model.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 const CHEAP_PROVIDER = "sakana-ai-console";
 const CHEAP_MODEL = "fugu";
@@ -19,13 +19,18 @@ const isCreatePrRequest = (text: string) => {
   return CREATE_PR_PATTERNS.some((pattern) => pattern.test(text));
 };
 
+const isCheapModel = (model: ExtensionContext["model"]) =>
+  model?.provider === CHEAP_PROVIDER && model.id === CHEAP_MODEL;
+
 export default function cheapPrModel(pi: ExtensionAPI) {
+  let restoreModel: NonNullable<ExtensionContext["model"]> | undefined;
+
   pi.on("input", async (event, ctx) => {
     if (event.source === "extension") return;
     if (!isCreatePrRequest(event.text)) return;
-    if (ctx.model.provider === CHEAP_PROVIDER && ctx.model.id === CHEAP_MODEL) {
-      return;
-    }
+
+    const currentModel = ctx.model;
+    if (!currentModel || isCheapModel(currentModel)) return;
 
     const model = ctx.modelRegistry.find(CHEAP_PROVIDER, CHEAP_MODEL);
     if (!model) {
@@ -39,11 +44,30 @@ export default function cheapPrModel(pi: ExtensionAPI) {
     }
 
     const switched = await pi.setModel(model);
+    if (switched) {
+      restoreModel = currentModel;
+    }
+
     if (ctx.hasUI) {
       const level = switched ? "info" : "warning";
       const message = switched
         ? `PR作成のため安価モデルに切替: ${CHEAP_PROVIDER}/${CHEAP_MODEL}`
         : `PR作成用モデルに切替できませんでした: ${CHEAP_PROVIDER}/${CHEAP_MODEL}`;
+      ctx.ui.notify(message, level);
+    }
+  });
+
+  pi.on("agent_settled", async (_event, ctx) => {
+    const model = restoreModel;
+    restoreModel = undefined;
+    if (!model || !isCheapModel(ctx.model)) return;
+
+    const restored = await pi.setModel(model);
+    if (ctx.hasUI) {
+      const level = restored ? "info" : "warning";
+      const message = restored
+        ? `PR作成後にモデルを復元: ${model.provider}/${model.id}`
+        : `PR作成前のモデルに復元できませんでした: ${model.provider}/${model.id}`;
       ctx.ui.notify(message, level);
     }
   });


### PR DESCRIPTION
## Summary
- `cheap-pr-model.ts` に、PR作成後の元モデル復元処理を追加
- PR作成依頼で `sakana-ai-console/fugu` に切り替えた後、切替前のモデル（通常 `fugu-ultra`）を `agent_settled` で自動的に戻す
- 現在モデルが `fugu` のときだけ復元し、ユーザーが手動で別モデルに切り替えた場合は上書きしない
- 従来は `fugu` に切り替えるだけで戻す処理がなく、次の通常作業も `fugu` のまま始まっていた問題を解消

## Verification
- `PI_CODING_AGENT_DIR=$PWD/pi/agent pi --list-models` で拡張ロードにエラーが出ないことを確認（API key 未設定のため models 自体は空表示）