### PR TITLE
feat(pi): auto-continue work after auto-compaction

### DIFF
--- a/pi/agent/extensions/auto-continue-after-compact.ts
+++ b/pi/agent/extensions/auto-continue-after-compact.ts
@@ -1,0 +1,34 @@
+/**
+ * 自動コンパクト後に、中断した作業を自動継続する拡張。
+ *
+ * why: pi は overflow 型の自動コンパクト（LLM 呼び出し中に context 超過）なら
+ * willRetry:true で中断ターンを自動リトライするが、threshold 型
+ * （ターン完了後に閾値超過で発火）や、リトライされない overflow ではそこで
+ * 会話が止まる。長時間の自律作業ではここで手が止まるので、コンパクト直後の
+ * idle 時に継続メッセージを 1 通だけ送って作業を再開させる。
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const CONTINUE_MESSAGE =
+  "(自動継続) 直前に自動コンパクトが実行されました。要約と直近の文脈をもとに、" +
+  "中断していた作業をそのまま続けてください。すでに完了している場合は、" +
+  "その旨だけ短く報告して追加の作業はしないでください。";
+
+export default function autoContinueAfterCompact(pi: ExtensionAPI) {
+  // コンパクト検知から settle まで持ち越し、idle になった瞬間に 1 回だけ継続する
+  let continueAfterSettle = false;
+
+  pi.on("session_compact", (event) => {
+    // 手動 /compact は対象外。willRetry:true は pi が自動リトライ済みなので対象外。
+    if (event.reason !== "manual" && !event.willRetry) {
+      continueAfterSettle = true;
+    }
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    if (!continueAfterSettle) return;
+    continueAfterSettle = false; // 継続は 1 回だけ（多重・無限ループ防止）
+    if (!ctx.isIdle()) return;
+    pi.sendUserMessage(CONTINUE_MESSAGE);
+  });
+}


### PR DESCRIPTION
## Summary
- 自動コンパクト後に中断作業を自動継続する pi 拡張 `auto-continue-after-compact.ts` を追加
- `session_compact` で `manual` 以外かつ `willRetry: false`（主に threshold 型）のときだけ継続フラグを立て、`agent_settled` で idle 確認後に継続メッセージを1回だけ送る
- overflow 型（`willRetry: true`）は pi 標準が中断ターンを自動リトライ済みのため対象外。フラグ即クリアで多重・無限ループを防止

## Verification
- 本体を node_modules に symlink して `tsc` 型チェック → エラーゼロ
- `deno lint` / `deno fmt --check` → クリーン