### PR TITLE
feat(devbox): add hunk diff viewer and link its review skill

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -22,7 +22,6 @@
     ],
     "defaultMode": "bypassPermissions"
   },
-  "model": "sonnet",
   "hooks": {
     "PreToolUse": [
       {

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -53,7 +53,8 @@
     "shellcheck@latest",
     "shfmt@latest",
     "taplo@latest",
-    "github:yusukebe/ax"
+    "github:yusukebe/ax",
+    "hunk@latest"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -36,7 +36,6 @@
     "vtsls@latest",
     "pnpm@latest",
     "git@latest",
-    "delta@latest",
     "cursor-cli@latest",
     "wget@latest",
     "gettext@latest",

--- a/jjconfig.toml
+++ b/jjconfig.toml
@@ -13,8 +13,8 @@ diff-formatter = ["difft", "--color=always", "$left", "$right"]
 
 [aliases]
 current = ["log", "-r", "@ | @-"]
-diffn = ["diff", "--git", "--config=ui.pager=delta -n"]
-diffs = ["diff", "--git", "--config=ui.pager=delta -s"]
+diffn = ["diff", "--git", "--config=ui.pager=hunk pager --line-numbers"]
+diffs = ["diff", "--git", "--config=ui.pager=hunk pager --mode split"]
 
 [remotes.origin]
 auto-track-bookmarks = "glob:*"

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,6 +1,6 @@
 {
   "defaultProvider": "sakana-ai-console",
-  "defaultModel": "fugu",
+  "defaultModel": "fugu-ultra",
   "defaultThinkingLevel": "medium",
   "theme": "dark",
   "defaultProjectTrust": "ask",

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -22,5 +22,5 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.80.10"
+  "lastChangelogVersion": "0.82.0"
 }

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -181,3 +181,13 @@ for SKILL in ${BASE_DIR}/.agents/skills/cmux*(N/) ${BASE_DIR}/.agents/skills/che
   fi
   ln -sfn "${SKILL}" "${DEST}"
 done
+
+# hunk-review: stable Devbox profile path keeps the bundled skill in sync with Hunk updates
+HUNK_SKILL_SRC="$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/share/hunk/skills/hunk-review"
+HUNK_SKILL_DEST="$HOME/.agents/skills/hunk-review"
+if [ -L "${HUNK_SKILL_DEST}" ]; then
+  rm "${HUNK_SKILL_DEST}"
+elif [ -e "${HUNK_SKILL_DEST}" ]; then
+  mv "${HUNK_SKILL_DEST}" "$HOME/.agents/skill-backups/hunk-review.backup-$(date +%Y%m%d%H%M%S)"
+fi
+ln -sfn "${HUNK_SKILL_SRC}" "${HUNK_SKILL_DEST}"

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -247,6 +247,22 @@ for SKILL in $SHARED_AGENT_SKILLS
     end
 end
 
+# hunk-review: stable Devbox profile path keeps the bundled skill in sync with Hunk updates
+set HUNK_SKILL_SRC $DEVBOX_GLOBAL_DIR/.devbox/nix/profile/default/share/hunk/skills/hunk-review
+set HUNK_SKILL_DEST $AGENTS_SKILL_DIR/hunk-review
+if test -L $HUNK_SKILL_DEST
+    rm $HUNK_SKILL_DEST
+else if test -e $HUNK_SKILL_DEST
+    set BACKUP "$AGENTS_SKILL_BACKUP_DIR/hunk-review.backup-"(date +%Y%m%d%H%M%S)
+    print_warning "Backing up existing agent skill: $HUNK_SKILL_DEST -> $BACKUP"
+    mv $HUNK_SKILL_DEST $BACKUP
+end
+if ln -sfn $HUNK_SKILL_SRC $HUNK_SKILL_DEST
+    print_success "Linked agent skill: hunk-review"
+else
+    print_error "Failed to link agent skill: $HUNK_SKILL_DEST"
+end
+
 echo ""
 
 echo "🎉 Fish configuration setup completed!"


### PR DESCRIPTION
## Summary
- `devbox/devbox.json`: add `hunk@latest` (modem-dev/hunk) and remove `delta@latest`
- link the official `hunk-review` skill into `~/.agents/skills/hunk-review` via the stable Devbox profile path, so it tracks Hunk updates instead of vendoring a copy
- `scripts/build_env/setup_fish.sh` / `scripts/build_env/create_symlink.sh`: recreate that link during setup
- route the existing Jujutsu `diffn` / `diffs` aliases through `hunk pager` instead of delta
- set Pi's default model to `fugu-ultra`
- drop stale `model: sonnet` from `claude/settings.json` and bump `lastChangelogVersion` in `pi/agent/settings.json`

## Notes
- `parallel-review` remains the default for generic review requests; `hunk-review` is only for an active Hunk session or explicit interactive Hunk review.

## Verification
- `fish -n scripts/build_env/setup_fish.sh`
- `zsh -n scripts/build_env/create_symlink.sh`
- `jq empty devbox/devbox.json claude/settings.json pi/agent/settings.json`
- `taplo check jjconfig.toml`
- `devbox global install` removes delta and keeps Hunk 0.17.0 available
- `jj diffn` / `jj diffs` resolve to Hunk pager options
- `hunk session list/get/context/review` works
