### PR TITLE
fix(fish): make ghq-fzf Ctrl+S fast and fresh via fd signature

### DIFF
--- a/.agents/skills/review-report/SKILL.md
+++ b/.agents/skills/review-report/SKILL.md
@@ -90,6 +90,7 @@ Prompt 雛形: [references/prompts.md](references/prompts.md) の Stage 3。
 
 - 両結果を main agent が統合。Stage 1 finding は「plan と整合する」という理由だけで削除しない。
 - 最終 group risk は security/correctness、blast radius、irreversibility、uncertainty、test gaps を考慮し、二レビュアーの **高い方** を基本に main agent が決める。`riskScore` は同一 risk の tie-break のみ。
+- ただし severity/risk は **その指摘固有の実害** で判断し、周辺機能の重大さ（例: 削除フロー＝不可逆）を機械的に継承しない。既存の緩和策（操作が完走/ロールバック、toast 等で別経路のフィードバックが残る、ボタン disabled 済み 等）と到達性・発生頻度を織り込み **過大評価を避ける**。irreversibility 等の risk 要因は指摘の欠陥自体に本当に当てはまる時だけ加点する。二レビュアーの高い方を採る前に、その severity が固有実害に見合うか main agent が検算する。
 - グループ表示順: `critical > high > medium > low` → `riskScore` 降順 → 入力順。
 - 各 changed hunk は（秘密除外を除き）**ちょうど1つの intent group** に所属。1 file に複数 intent があれば複数 group の `files` に出てよい。diff は論理/因果順で並べる。
 - 重複 finding は root cause + impact + remediation が同じ場合だけ merge して `source: both`。単に同じ file だから merge しない。

--- a/.agents/skills/review-report/references/prompts.md
+++ b/.agents/skills/review-report/references/prompts.md
@@ -55,6 +55,12 @@ cp "$PLAN_BODY" "$PLAN_DIR/plan-body.md"
 5. findings（source=blind）:
    - id, severity, title, location, problem, evidence, suggestion
    - 渡された差分だけから根拠を示せる指摘に限定する
+   - severity 較正（過大評価を避ける・厳守）:
+     - その指摘固有の欠陥が現実に招く最悪ケースの影響で決める。周辺機能の重大さ（例: 削除＝不可逆）を指摘へ機械的に継承しない
+     - 既存の緩和策を織り込む（例外時も操作は完走/ロールバックされる、toast 等でフィードバックが別経路に残る、ボタンが disabled 済み 等があれば下げる）
+     - 到達性・発生頻度を考慮する。レア経路・短い時間窓でしか起きないものを上げすぎない
+     - irreversibility / blast-radius 等の risk 要因は、その欠陥自体に本当に当てはまる時だけ加点する（文脈語に引きずられない）
+     - critical/high はデータ破壊・情報漏洩・不可逆な誤操作・全体停止など実害が大きく現実的なものに限る。UX 微調整・防御的コードの穴・レアな不整合は low〜medium
 
 intent を説明できないグループは needsImprovement=true + improvementReason。
 重大度順。指摘なしグループは findings 空でよい。
@@ -96,6 +102,12 @@ patch 省略・truncate した場合は explanation に明示する（silent omi
 5. findings（source=plan-aware）:
    - id, severity, title, location, problem, evidence, suggestion, planOnly
    - plan-body.md を読まないと判定できない指摘は planOnly=true、それ以外は false
+   - severity 較正（過大評価を避ける・厳守）:
+     - その指摘固有の欠陥が現実に招く最悪ケースの影響で決める。周辺機能の重大さ（例: 削除＝不可逆）を指摘へ機械的に継承しない
+     - 既存の緩和策を織り込む（例外時も操作は完走/ロールバックされる、toast 等でフィードバックが別経路に残る、ボタンが disabled 済み 等があれば下げる）
+     - 到達性・発生頻度を考慮する。レア経路・短い時間窓でしか起きないものを上げすぎない
+     - irreversibility / blast-radius 等の risk 要因は、その欠陥自体に本当に当てはまる時だけ加点する（文脈語に引きずられない）
+     - critical/high はデータ破壊・情報漏洩・不可逆な誤操作・全体停止など実害が大きく現実的なものに限る。UX 微調整・防御的コードの穴・レアな不整合は low〜medium
 
 intent を説明できないグループは needsImprovement=true + improvementReason。
 Stage 1 の結果は参照しない — 独立に判定する。

--- a/fish/functions/ghq-fzf.fish
+++ b/fish/functions/ghq-fzf.fish
@@ -1,12 +1,21 @@
 function ghq-fzf --description 'Select ghq repository with fzf and change directory'
     set -l cache_file "$HOME/.cache/ghq-fzf-list"
+    set -l sig_file "$HOME/.cache/ghq-fzf-list.sig"
 
     # --refresh でキャッシュを再生成（workspace追加時など手動更新用）
     if test "$argv[1]" = --refresh
-        rm -f $cache_file
+        rm -f $cache_file $sig_file
     end
 
     set -l ghq_root (ghq root)
+
+    # .git/.jj ディレクトリ一覧を軽量シグネチャにし、clone/workspace の増減を検知する
+    # (ghq list は遅いので使わない。fd スキャンは ~0.15s で毎回実行できる)
+    set -l sig (fd -H -t d -d 5 '^\.(git|jj)$' $ghq_root 2>/dev/null | sort | shasum | string split -f1 ' ')
+    if not test -f "$sig_file"; or test "$sig" != (cat $sig_file 2>/dev/null)
+        rm -f $cache_file
+        echo $sig > $sig_file
+    end
 
     # キャッシュが無ければリストを生成して保存（clone/workspace追加時のみ更新が必要）
     if not test -f $cache_file


### PR DESCRIPTION
## Summary
- Ctrl+S の `ghq-fzf` はキャッシュ `~/.cache/ghq-fzf-list` を使うため、`ghq get` の clone や jj workspace 追加後にリストが最新化されない問題を修正
- かといって毎回 `ghq list` で検知すると ~2.8s かかり遅すぎた（20 repos でも遅い）
- `.git`/`.jj` ディレクトリ一覧を `fd`（~0.15s）で取って軽量シグネチャにし、毎回比較。増減があったときだけキャッシュを再生成する
- clone も workspace 追加も **1回の押下で反映**され、通常時は高速なまま
- `--refresh` は sig ファイル（`~/.cache/ghq-fzf-list.sig`）も削除する

## Verification
- `fish -n fish/functions/ghq-fzf.fish` 構文チェック OK
- warm（sig 一致）時のコスト: fd シグネチャ ~0.15s（従来 ~2.8s から改善）
- stale（sig 不一致）検知でキャッシュ再生成されることを確認