### PR TITLE
fix(pi): symlink pi/agent/lib so extensions resolve ../lib

### DIFF
--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -149,6 +149,7 @@ ln -sf ${BASE_DIR}/pi/agent/AGENTS.md ~/.pi/agent/AGENTS.md
 ln -sf ${BASE_DIR}/pi/agent/settings.json ~/.pi/agent/settings.json
 ln -sf ${BASE_DIR}/pi/agent/models.json ~/.pi/agent/models.json
 ln -sfn ${BASE_DIR}/pi/agent/extensions ~/.pi/agent/extensions
+ln -sfn ${BASE_DIR}/pi/agent/lib ~/.pi/agent/lib
 if command -v npm >/dev/null 2>&1; then
   bash "${BASE_DIR}/scripts/build_env/patch_pi_min_output_tokens.sh"
 else

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -195,6 +195,7 @@ create_symlink $BASE_DIR/pi/agent/APPEND_SYSTEM.md $PI_AGENT_DIR/APPEND_SYSTEM.m
 create_symlink $BASE_DIR/pi/agent/settings.json $PI_AGENT_DIR/settings.json "Pi settings"
 create_symlink $BASE_DIR/pi/agent/models.json $PI_AGENT_DIR/models.json "Pi custom models"
 create_symlink $BASE_DIR/pi/agent/extensions $PI_AGENT_DIR/extensions "Pi extensions"
+create_symlink $BASE_DIR/pi/agent/lib $PI_AGENT_DIR/lib "Pi extension lib"
 if command -q npm
     bash $BASE_DIR/scripts/build_env/patch_pi_min_output_tokens.sh
 else


### PR DESCRIPTION
## Summary
- pi 起動時に `auto-fugu-model.ts` 拡張が `../lib/fugu-model-routing.ts` を解決できず `Cannot find module` で失敗していた。
- 原因: setup スクリプトが `extensions` だけ symlink し、`pi/agent/lib` を symlink していなかった（pi は symlink 実体ではなく `~/.pi/agent/extensions/` 基準でモジュールを解決するため `~/.pi/agent/lib/` を探す）。
- `create_symlink.sh` と `setup_fish.sh` の両方に `lib` の symlink 行を追加して再発を防止。

## Verification
- 手元で `~/.pi/agent/lib -> dotfiles/pi/agent/lib` を作成し、`~/.pi/agent/lib/fugu-model-routing.ts` が解決されることを確認。