### PR TITLE
fix(fish): disable Ctrl+S/Ctrl+Q flow control (stty -ixon)

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -62,6 +62,11 @@ end
 # Fish specific settings
 set fish_greeting ""  # 起動メッセージを非表示
 
+# Ctrl+S/Ctrl+Q のフロー制御(XOFF/XON)を無効化（端末が固まるのを防ぐ）
+if status is-interactive
+    stty -ixon
+end
+
 # プロンプト設定（zshから移行）
 # %F{163}λ%f の再現
 function fish_prompt


### PR DESCRIPTION
## Summary
- fish の対話セッションで Ctrl+S を押すと端末のフロー制御 (XOFF) が発火し、画面が固まって「重い」ように見えていた。
- `config.fish` に `status is-interactive` ガード付きで `stty -ixon` を追加し、XOFF/XON によるフロー制御を無効化。
- スクリプト実行や tty の無い環境では実行されない。

## Verification
- `fish -n fish/config.fish` で構文チェック OK。
- 新規シェルで Ctrl+S を押しても端末が固まらないことを確認予定（既存セッションは `stty -ixon` を一度実行で即反映）。