### PR TITLE
chore(skills): track cmux-task-name skill; sync codex config

### DIFF
--- a/.agents/skills/cmux-task-name/SKILL.md
+++ b/.agents/skills/cmux-task-name/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cmux-task-name
+description: 現在の cmux workspace の名前と説明を、いま取り組んでいるタスクに合わせて自動更新する。新しいタスク・ブランチ・PR に着手したとき、jj bookmark / workspace を切ったとき、あるいはユーザーが「cmux のワークスペース名をタスク名にして」「セッション名を更新して」と言ったときに使う。名前だけでなく説明(set-description)も付ける。
+---
+
+# cmux Task Name Sync
+
+いま作業中のタスクが一目で分かるように、**現在の cmux workspace** の名前と説明をタスク内容に同期する。cmux CLI（`cmux`、`CMUX_BUNDLED_CLI_PATH`）の socket 経由で実行する。
+
+## いつ発動するか
+
+- 新しいタスク／ブランチ／PR に着手したとき（`jj bookmark create` / `jj workspace add` の直後を含む）
+- ユーザーが名前・説明の更新を明示したとき
+- タスクの目的が大きく変わったとき（名前と説明を更新し直す）
+
+cmux 外で動いている（`CMUX_WORKSPACE_ID` が無い）場合は何もしない。
+
+## 対象の決め方
+
+- **常に現在の workspace を対象にする。** `--workspace` を省けば `$CMUX_WORKSPACE_ID`（現在の caller workspace）が対象になる。他 workspace はユーザーが明示したときだけ触る。
+- 事前確認: `cmux current-workspace` で選択中の workspace を確認できる。
+
+## 名前と説明の作り方
+
+タスク文脈から次を自動生成する（ユーザー指定があればそれを優先）。
+
+- **名前（title）**: 短く識別できる slug。優先順は
+  1. jj bookmark 名の末尾セグメント（`fix/email-builder-custom-block-delete-confirm` → `email-builder-custom-block-delete-confirm`）
+  2. jj workspace 名（`crm-<用途>` の `<用途>`、例: `custom-block-delete`）
+  3. タスク要約から作った短い slug
+  - 目安 40 文字以内。長い prefix（`fix/` `feat/`）は落としてよい。
+- **説明（description）**: 原則 **1 行**で簡潔に。`<タスクの一行要約> (PR #<番号>)` の形。
+  - 例: `カスタムブロック削除に確認ダイアログを追加 (PR #2988)`
+  - PR がまだ無ければ `(PR #...)` は省く。
+  - bookmark / jj workspace path など詳細は名前や PR から辿れるので説明には入れない。
+
+## 実行手順
+
+```bash
+# 0. cmux 外なら中断（CMUX_WORKSPACE_ID が無い）
+[ -n "$CMUX_WORKSPACE_ID" ] || exit 0
+
+# 1. 名前を更新（--workspace 省略で現在の workspace が対象）
+cmux rename-workspace "<name>"
+
+# 2. 説明を更新（1 行で簡潔に）
+cmux workspace-action --action set-description --description "<一行要約> (PR #<番号>)"
+
+# 3. 確認
+cmux current-workspace
+cmux workspace list | grep -F "<name>"
+```
+
+- 名前を消す: `cmux workspace-action --action clear-name`
+- 説明を消す: `cmux workspace-action --action clear-description`
+- 任意で色分け: `cmux workspace-action --action set-color --color <Red|Blue|Green|...|#RRGGBB>`（タスク種別で色を固定運用しても良い）
+
+## jj / PR フローとの連携
+
+- `jj-workspace` skill で jj workspace を切ったら、続けてこの skill で cmux workspace 名を `<用途>` に合わせる。
+- `cheap-pr` で PR を作ったら、説明に `PR #<番号>` を追記して更新する。
+
+## 注意
+
+- 破壊的操作ではないが、対象を間違えないよう **現在の workspace 以外は明示指定時のみ**。
+- socket が使えない（`cmux ping` が失敗する）環境では中断し、その旨を伝える。
+- 名前・説明はユーザー可視。秘密情報（トークン等）は入れない。

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -7,6 +7,8 @@ developer_instructions = "## Per-directory instructions\n作業対象のファ�
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
+notify = ["/Users/roy/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended"]
+
 [projects."/Users/roy/.config/fish"]
 trust_level = "trusted"
 
@@ -32,10 +34,38 @@ trust_level = "trusted"
 rmcp_client = true
 image_generation = false
 apps = false
+js_repl = false
 
 [mcp_servers.devin]
 url = "https://mcp.devin.ai/mcp"
 bearer_token_env_var = "DEVIN_API_KEY"
+
+[mcp_servers.node_repl]
+args = []
+command = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl"
+startup_timeout_sec = 120
+
+[mcp_servers.node_repl.env]
+NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
+NODE_REPL_NODE_MODULE_DIRS = "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
+NODE_REPL_NODE_PATH = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+NODE_REPL_TRUSTED_CODE_PATHS = "/Users/roy/.codex"
+CODEX_HOME = "/Users/roy/.codex"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "028a14b6eaa6d98dac2aae00764345ab9f244801ed8493d42b9af3be5575006e,8785b5437d98636c3002d3d7e64b98db79c3b66870b1bd3d18dea953a99b1562"
+BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
+NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
+NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
+NODE_REPL_INSTRUCTIONS_USE_CASE_COMPUTER_USE = "Control desktop apps on macOS through Computer Use."
+BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
+BROWSER_USE_CODEX_APP_VERSION = "26.727.40816"
+SKY_CUA_SERVICE_PATH = "/Users/roy/.codex/computer-use/Codex Computer Use.app"
+CODEX_CLI_PATH = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+[mcp_servers.computer-use]
+command = "./Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient"
+args = ["mcp"]
+cwd = "."
+enabled = false
 
 [shell_environment_policy]
 inherit = "core"
@@ -46,6 +76,9 @@ ENABLE_LSP_TOOL = "true"
 CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1"
 CLAUDE_CODE_NO_FLICKER = "1"
 USE_BUILTIN_RIPGREP = "0"
+BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "028a14b6eaa6d98dac2aae00764345ab9f244801ed8493d42b9af3be5575006e,8785b5437d98636c3002d3d7e64b98db79c3b66870b1bd3d18dea953a99b1562"
+NODE_REPL_TRUSTED_CODE_PATHS = "/Users/roy/.codex"
 
 [hooks.state]
 
@@ -54,3 +87,46 @@ trusted_hash = "sha256:24040b144c1aa832f157332887d96e444f92ac77deec3fa9667c38e8d
 
 [tui.model_availability_nux]
 "gpt-5.5" = 1
+
+[desktop]
+followUpQueueMode = "queue"
+
+[marketplaces.openai-bundled]
+last_updated = "2026-08-04T01:20:06Z"
+source_type = "local"
+source = "/Users/roy/.codex/.tmp/bundled-marketplaces/openai-bundled"
+
+[marketplaces.openai-primary-runtime]
+last_updated = "2026-08-03T02:35:10Z"
+source_type = "local"
+source = "/Users/roy/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
+
+[plugins."sites@openai-bundled"]
+enabled = true
+
+[plugins."browser@openai-bundled"]
+enabled = true
+
+[plugins."chrome@openai-bundled"]
+enabled = true
+
+[plugins."computer-use@openai-bundled"]
+enabled = true
+
+[plugins."visualize@openai-bundled"]
+enabled = true
+
+[plugins."documents@openai-primary-runtime"]
+enabled = true
+
+[plugins."pdf@openai-primary-runtime"]
+enabled = true
+
+[plugins."spreadsheets@openai-primary-runtime"]
+enabled = true
+
+[plugins."presentations@openai-primary-runtime"]
+enabled = true
+
+[plugins."template-creator@openai-primary-runtime"]
+enabled = true


### PR DESCRIPTION
## Summary
- `~/.agents/skills/cmux-task-name/SKILL.md` をリポジトリ管理下に移動 (`.agents/skills/cmux-task-name/`)。`create_symlink.sh` の `.agents/skills/cmux*` glob で自動 symlink されるためスクリプト変更は不要。
- `codex/config.toml` を現行環境の状態に同期（Codex デスクトップアプリ由来の設定含む）。

## Verification
- symlink 張り替え後、`~/.agents/skills/cmux-task-name/SKILL.md` が repo 経由で読めることを確認。
- `jj status` で `A .agents/skills/cmux-task-name/SKILL.md` と `M codex/config.toml` を確認。