### PR TITLE
chore(pi): default to cursor/grok-4.5 and document pi-cursor auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pi/agent/trust.json
 pi/agent/sessions/
 pi/agent/git/
 pi/agent/npm/
+
+# Pi local model store
+pi/agent/models-store.json

--- a/pi/README.md
+++ b/pi/README.md
@@ -49,7 +49,8 @@ Use Pi's built-in subscription flow when possible:
 /model
 ```
 
-The default model is `sakana-ai-console/fugu` (set in `settings.json`).
+The default model is `cursor/grok-4.5` with thinking level `high`
+(set in `settings.json`).
 
 Tracked custom providers:
 
@@ -57,12 +58,17 @@ Tracked custom providers:
 - `sakana-ai-console/fugu-ultra`
 - `lm-studio/*` (dynamically loaded from `LM_STUDIO_BASE_URL` or
   `http://localhost:1234/v1`)
+- `cursor/*` via `@rahularya01/pi-cursor` (subscription / OAuth; unofficial)
 
 Environment variables:
 
 ```bash
 export LM_STUDIO_BASE_URL="http://localhost:1234/v1"  # Optional
 export LM_STUDIO_API_KEY="..."           # Optional; dummy key is used if unset
+# Optional. Prefer the package default (or cli-2026.07.23-e383d2b).
+# Do NOT set this to the latest `agent --version` string — that can cause
+# resource_exhausted / wire-drift failures.
+# export PI_CURSOR_CLIENT_VERSION="cli-2026.07.23-e383d2b"
 ```
 
 ### Sakana API key
@@ -85,16 +91,52 @@ security find-generic-password -w -s fugu-api-key >/dev/null
 If you do not want to use Keychain, edit `~/.pi/agent/auth.json` and store a
 literal API key or an environment reference such as `$SAKANA_API_KEY`.
 
+### Cursor models (`@rahularya01/pi-cursor`)
+
+Unofficial community package (most-downloaded OAuth Cursor provider on
+pi.dev). Uses Cursor subscription auth — not the official `@cursor/sdk` API-key
+path. Recorded in `settings.json` as `packages: ["npm:@rahularya01/pi-cursor"]`
+and installed under `~/.pi/agent/npm/` (not tracked).
+
+```bash
+pi install npm:@rahularya01/pi-cursor   # already in settings.json; re-run on a new machine
+pi --list-models cursor
+pi --model cursor/composer-2
+```
+
+Auth (pick one):
+
+1. Preferred: already logged in via `agent login` / Cursor Desktop, then sync
+   Keychain tokens into Pi's auth store:
+
+   ```bash
+   ./scripts/build_env/sync_pi_cursor_auth.sh
+   ```
+
+2. Or inside pi: `/login cursor` (browser PKCE OAuth)
+
+Useful commands: `/cursor.doctor`, `/cursor.usage`, `/cursor.models`.
+Details: https://pi.dev/packages/@rahularya01/pi-cursor
+
+Note: this reverse-engineers Cursor's agent wire protocol and can break when
+Cursor changes it. Verified working against npm `1.4.8` with the package default
+client version (and with `PI_CURSOR_CLIENT_VERSION=cli-2026.07.23-e383d2b`).
+Setting `PI_CURSOR_CLIENT_VERSION` to the current `agent --version`
+(`2026.08.04-…`) currently triggers `resource_exhausted`. Open PR
+https://github.com/Rahularya01/pi-cursor/pull/4 improves GOAWAY / heartbeat
+handling but is not required for basic prompts.
+
 ## Extensions
 
-Configured by `settings.json` via `extensions/*.ts`.
+Configured by `settings.json` via `extensions/*.ts` and npm packages.
 
-| Extension                       | Purpose                                                              |
+| Extension / package             | Purpose                                                              |
 | ------------------------------- | -------------------------------------------------------------------- |
 | `local-openai.ts`               | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
+| `npm:@rahularya01/pi-cursor`    | Cursor subscription models via OAuth / CLI Keychain (unofficial). |
 
 Reload after editing extensions:
 

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,7 +1,12 @@
 {
-  "defaultProvider": "sakana-ai-console",
-  "defaultModel": "fugu",
-  "defaultThinkingLevel": "medium",
+  "defaultProvider": "cursor",
+  "defaultModel": "grok-4.5",
+  "defaultThinkingLevel": "high",
+  "enabledModels": [
+    "cursor/composer-2.5-fast",
+    "cursor/grok-4.5:high",
+    "cursor/grok-4.5-fast:high"
+  ],
   "theme": "dark",
   "defaultProjectTrust": "ask",
   "enableInstallTelemetry": false,
@@ -22,5 +27,8 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.83.0"
+  "lastChangelogVersion": "0.84.1",
+  "packages": [
+    "npm:@rahularya01/pi-cursor"
+  ]
 }

--- a/scripts/build_env/sync_pi_cursor_auth.sh
+++ b/scripts/build_env/sync_pi_cursor_auth.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Sync Cursor Agent CLI / Desktop Keychain tokens into ~/.pi/agent/auth.json
+# so @rahularya01/pi-cursor can mark the cursor provider as configured.
+set -euo pipefail
+
+AUTH_PATH="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/auth.json"
+ACCOUNT="${CURSOR_KEYCHAIN_ACCOUNT:-cursor-user}"
+
+if ! command -v security >/dev/null 2>&1; then
+	echo "macOS Keychain (security) is required" >&2
+	exit 1
+fi
+
+access="$(security find-generic-password -w -s cursor-access-token -a "$ACCOUNT" 2>/dev/null || true)"
+refresh="$(security find-generic-password -w -s cursor-refresh-token -a "$ACCOUNT" 2>/dev/null || true)"
+
+if [[ -z "$access" || -z "$refresh" ]]; then
+	echo "Cursor Keychain tokens not found (cursor-access-token / cursor-refresh-token)." >&2
+	echo "Log in with: agent login" >&2
+	echo "Or in pi: /login cursor" >&2
+	exit 1
+fi
+
+mkdir -p "$(dirname "$AUTH_PATH")"
+umask 077
+AUTH_PATH="$AUTH_PATH" ACCESS="$access" REFRESH="$refresh" python3 - <<'PY'
+import json, os, base64, time
+from pathlib import Path
+
+path = Path(os.environ["AUTH_PATH"])
+access = os.environ["ACCESS"]
+refresh = os.environ["REFRESH"]
+
+def jwt_exp_ms(token: str) -> int:
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        data = json.loads(base64.urlsafe_b64decode(payload.encode()))
+        exp = data.get("exp")
+        if isinstance(exp, (int, float)):
+            return int(exp * 1000)
+    except Exception:
+        pass
+    return int(time.time() * 1000) + 24 * 3600 * 1000
+
+auth = {}
+if path.exists():
+    auth = json.loads(path.read_text())
+
+auth["cursor"] = {
+    "type": "oauth",
+    "access": access,
+    "refresh": refresh,
+    "expires": jwt_exp_ms(access),
+}
+
+path.write_text(json.dumps(auth, indent=2) + "\n")
+path.chmod(0o600)
+print(f"Synced Cursor OAuth credentials into {path}")
+PY


### PR DESCRIPTION
## Summary
- Pi のデフォルトを `sakana-ai-console/fugu` から `cursor/grok-4.5` (thinking: high) に変更
- `@rahularya01/pi-cursor` を packages に追加し、有効モデルを `composer-2.5-fast` / `grok-4.5` / `grok-4.5-fast` に限定
- Cursor Keychain トークンを `~/.pi/agent/auth.json` へ同期する `sync_pi_cursor_auth.sh` と README を追加
- ローカル生成の `pi/agent/models-store.json` を gitignore

## Test plan
- [ ] `PI_CODING_AGENT_DIR=$PWD/pi/agent pi --list-models cursor` で cursor モデルが見える
- [ ] `./scripts/build_env/sync_pi_cursor_auth.sh` で auth.json に cursor oauth が入る
- [ ] 新規マシンで `pi install npm:@rahularya01/pi-cursor` 後に `/model cursor/grok-4.5` で起動できる
- [ ] sakana fugu / fugu-ultra / lm-studio が引き続き選択可能
