### PR TITLE
chore(pi): temporarily pin pi-cursor GOAWAY fix branch

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -65,7 +65,7 @@ Environment variables:
 ```bash
 export LM_STUDIO_BASE_URL="http://localhost:1234/v1"  # Optional
 export LM_STUDIO_API_KEY="..."           # Optional; dummy key is used if unset
-# Optional. Prefer the package default (or cli-2026.07.23-e383d2b).
+# Optional. The GOAWAY fix branch defaults to cli-2026.07.23-e383d2b.
 # Do NOT set this to the latest `agent --version` string — that can cause
 # resource_exhausted / wire-drift failures.
 # export PI_CURSOR_CLIENT_VERSION="cli-2026.07.23-e383d2b"
@@ -95,11 +95,13 @@ literal API key or an environment reference such as `$SAKANA_API_KEY`.
 
 Unofficial community package (most-downloaded OAuth Cursor provider on
 pi.dev). Uses Cursor subscription auth — not the official `@cursor/sdk` API-key
-path. Recorded in `settings.json` as `packages: ["npm:@rahularya01/pi-cursor"]`
-and installed under `~/.pi/agent/npm/` (not tracked).
+path. Recorded in `settings.json` as the GOAWAY-fix git branch (PR #4) until
+upstream npm publishes it:
+`git:github.com/kouvaliasnick/pi-cursor@fix/goaway-after-turn-ended`.
 
 ```bash
-pi install npm:@rahularya01/pi-cursor   # already in settings.json; re-run on a new machine
+# pi's git installer skips devDeps, so build dist via the setup script:
+./scripts/build_env/setup_pi_cursor_goaway_fix.sh
 pi --list-models cursor
 pi --model cursor/composer-2
 ```
@@ -119,12 +121,14 @@ Useful commands: `/cursor.doctor`, `/cursor.usage`, `/cursor.models`.
 Details: https://pi.dev/packages/@rahularya01/pi-cursor
 
 Note: this reverse-engineers Cursor's agent wire protocol and can break when
-Cursor changes it. Verified working against npm `1.4.8` with the package default
-client version (and with `PI_CURSOR_CLIENT_VERSION=cli-2026.07.23-e383d2b`).
-Setting `PI_CURSOR_CLIENT_VERSION` to the current `agent --version`
-(`2026.08.04-…`) currently triggers `resource_exhausted`. Open PR
-https://github.com/Rahularya01/pi-cursor/pull/4 improves GOAWAY / heartbeat
-handling but is not required for basic prompts.
+Cursor changes it. Upstream npm `1.4.8` still treats post-`turnEnded`
+`GOAWAY (errorCode=0)` as a hard error and appends wire-drift noise.
+We pin the open PR that completes those turns silently:
+https://github.com/Rahularya01/pi-cursor/pull/4
+(default client `cli-2026.07.23-e383d2b`). Do not set
+`PI_CURSOR_CLIENT_VERSION` to the current `agent --version` (`2026.08.04-…`);
+that currently triggers `resource_exhausted`. After upstream merges/publishes,
+switch `settings.json` back to `npm:@rahularya01/pi-cursor`.
 
 ## Extensions
 
@@ -136,7 +140,7 @@ Configured by `settings.json` via `extensions/*.ts` and npm packages.
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
-| `npm:@rahularya01/pi-cursor`    | Cursor subscription models via OAuth / CLI Keychain (unofficial). |
+| `git:…/pi-cursor@fix/goaway-after-turn-ended` | Cursor models via OAuth; silences post-turn GOAWAY (PR #4). |
 
 Reload after editing extensions:
 

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -29,6 +29,6 @@
   ],
   "lastChangelogVersion": "0.84.1",
   "packages": [
-    "npm:@rahularya01/pi-cursor"
+    "git:github.com/kouvaliasnick/pi-cursor@fix/goaway-after-turn-ended"
   ]
 }

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -152,6 +152,7 @@ ln -sfn ${BASE_DIR}/pi/agent/extensions ~/.pi/agent/extensions
 ln -sfn ${BASE_DIR}/pi/agent/lib ~/.pi/agent/lib
 if command -v npm >/dev/null 2>&1; then
   bash "${BASE_DIR}/scripts/build_env/patch_pi_min_output_tokens.sh"
+  bash "${BASE_DIR}/scripts/build_env/setup_pi_cursor_goaway_fix.sh"
 else
   echo "skip Pi runtime patch (npm not found)"
 fi

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -198,6 +198,7 @@ create_symlink $BASE_DIR/pi/agent/extensions $PI_AGENT_DIR/extensions "Pi extens
 create_symlink $BASE_DIR/pi/agent/lib $PI_AGENT_DIR/lib "Pi extension lib"
 if command -q npm
     bash $BASE_DIR/scripts/build_env/patch_pi_min_output_tokens.sh
+    bash $BASE_DIR/scripts/build_env/setup_pi_cursor_goaway_fix.sh
 else
     print_warning "Skipped Pi runtime patch (npm not found)"
 end

--- a/scripts/build_env/setup_pi_cursor_goaway_fix.sh
+++ b/scripts/build_env/setup_pi_cursor_goaway_fix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Install kouvaliasnick/pi-cursor@fix/goaway-after-turn-ended and build dist.
+# Upstream npm 1.4.8 still surfaces post-turnEnded GOAWAY as an error; PR #4 silences it.
+# pi's git installer runs `npm install --omit=dev`, which cannot run `prepare`/`tsup`,
+# so this script builds dist with full deps after clone/fetch.
+set -euo pipefail
+
+REF="${PI_CURSOR_GOAWAY_FIX_REF:-fix/goaway-after-turn-ended}"
+REPO_URL="${PI_CURSOR_GOAWAY_FIX_REPO:-https://github.com/kouvaliasnick/pi-cursor.git}"
+TARGET="${PI_CURSOR_GOAWAY_FIX_DIR:-$HOME/.pi/agent/git/github.com/kouvaliasnick/pi-cursor}"
+SETTINGS_SOURCE="git:github.com/kouvaliasnick/pi-cursor@${REF}"
+
+mkdir -p "$(dirname "$TARGET")"
+
+if [[ ! -d "$TARGET/.git" ]]; then
+	git clone --depth 1 -b "$REF" "$REPO_URL" "$TARGET"
+else
+	git -C "$TARGET" remote set-url origin "$REPO_URL"
+	git -C "$TARGET" fetch --depth 1 origin "$REF"
+	git -C "$TARGET" checkout -B "$REF" "FETCH_HEAD"
+fi
+
+# Full install so tsup is available for build; dist/ is gitignored.
+npm install --prefix "$TARGET"
+npm run --prefix "$TARGET" build
+
+# Runtime deps only for day-to-day loads (keeps the tree closer to pi's installer).
+npm install --prefix "$TARGET" --omit=dev --ignore-scripts
+
+if [[ ! -f "$TARGET/dist/index.js" ]]; then
+	echo "pi-cursor GOAWAY fix build failed: missing $TARGET/dist/index.js" >&2
+	exit 1
+fi
+
+if ! grep -q 'goaway_after_turn_ended' "$TARGET/dist/index.js"; then
+	echo "pi-cursor GOAWAY fix build missing goaway_after_turn_ended handler" >&2
+	exit 1
+fi
+
+echo "Installed $SETTINGS_SOURCE"
+echo "Built: $TARGET/dist/index.js"
+echo "Restart pi (or /reload) to pick up the provider."


### PR DESCRIPTION
## Summary
- `@rahularya01/pi-cursor` の npm 版 (1.4.8) は turn 終了後の `GOAWAY (errorCode=0)` をエラー扱いにしてノイズが出るため、暫定で upstream PR [#4](https://github.com/Rahularya01/pi-cursor/pull/4) 相当の git ブランチ `kouvaliasnick/pi-cursor@fix/goaway-after-turn-ended` を pin する
- pi の git installer は `npm install --omit=dev` のため dist がビルドできないので、`setup_pi_cursor_goaway_fix.sh` で clone + build する
- symlink / fish setup から同スクリプトを呼ぶよう配線し、README にも手順を追記

**一時対応:** upstream が merge / npm publish したら `pi/agent/settings.json` の `packages` を `npm:@rahularya01/pi-cursor` に戻し、本セットアップスクリプトは削除または不要化する。

Depends on #68.

## Test plan
- [ ] `./scripts/build_env/setup_pi_cursor_goaway_fix.sh` が `~/.pi/agent/git/github.com/kouvaliasnick/pi-cursor/dist/index.js` を生成する
- [ ] dist に `goaway_after_turn_ended` ハンドラが含まれる
- [ ] `PI_CODING_AGENT_DIR=$PWD/pi/agent pi --list-models cursor` で cursor モデルが見える
- [ ] 通常の prompt 後に post-`turnEnded` GOAWAY ノイズが出ない