### PR TITLE
chore(pi): default to Claude/Codex models and document Anthropic auth

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -60,6 +60,10 @@ Tracked custom providers:
   `http://localhost:1234/v1`)
 - `cursor/*` via `@rahularya01/pi-cursor` (subscription / OAuth; unofficial)
 
+Built-in subscription providers (via `/login`):
+
+- `anthropic/*` — Claude Pro/Max OAuth (built into Pi; no extra package)
+
 Environment variables:
 
 ```bash
@@ -90,6 +94,34 @@ security find-generic-password -w -s fugu-api-key >/dev/null
 
 If you do not want to use Keychain, edit `~/.pi/agent/auth.json` and store a
 literal API key or an environment reference such as `$SAKANA_API_KEY`.
+
+### Claude Pro/Max (`anthropic`)
+
+Pi 0.84+ includes Claude Pro/Max OAuth. No `pi-anthropic-oauth` package is
+required. Third-party harness usage draws from
+[extra usage](https://claude.ai/settings/usage) and is billed per token, not
+against Claude plan rate limits.
+
+```bash
+pi --list-models anthropic
+pi --model anthropic/claude-sonnet-4-6
+```
+
+Auth (pick one):
+
+1. Preferred: already logged in via Claude Code, then sync Keychain tokens:
+
+   ```bash
+   ./scripts/build_env/sync_pi_claude_auth.sh
+   ```
+
+2. Or inside pi: `/login` → **Anthropic (Claude Pro/Max)** (browser PKCE OAuth)
+
+Check readiness:
+
+```bash
+pi auth check --provider anthropic --json
+```
 
 ### Cursor models (`@rahularya01/pi-cursor`)
 

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,11 +1,16 @@
 {
-  "defaultProvider": "cursor",
-  "defaultModel": "grok-4.5",
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-sonnet-5",
   "defaultThinkingLevel": "high",
   "enabledModels": [
-    "cursor/composer-2.5-fast",
-    "cursor/grok-4.5:high",
-    "cursor/grok-4.5-fast:high"
+    "anthropic/claude-sonnet-5:high",
+    "anthropic/claude-sonnet-5:max",
+    "anthropic/claude-opus-5:high",
+    "anthropic/claude-opus-5:max",
+    "openai-codex/gpt-5.6-sol:high",
+    "openai-codex/gpt-5.6-sol:max",
+    "openai-codex/gpt-5.6-terra:high",
+    "openai-codex/gpt-5.6-terra:max"
   ],
   "theme": "dark",
   "defaultProjectTrust": "ask",

--- a/scripts/build_env/sync_pi_claude_auth.sh
+++ b/scripts/build_env/sync_pi_claude_auth.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Sync Claude Code Keychain OAuth tokens into ~/.pi/agent/auth.json
+# so Pi's built-in Anthropic (Claude Pro/Max) provider is configured.
+set -euo pipefail
+
+AUTH_PATH="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/auth.json"
+KEYCHAIN_SERVICE="${CLAUDE_CODE_KEYCHAIN_SERVICE:-Claude Code-credentials}"
+
+if ! command -v security >/dev/null 2>&1; then
+	echo "macOS Keychain (security) is required" >&2
+	exit 1
+fi
+
+raw="$(security find-generic-password -w -s "$KEYCHAIN_SERVICE" 2>/dev/null || true)"
+if [[ -z "$raw" ]]; then
+	echo "Claude Code Keychain item not found ($KEYCHAIN_SERVICE)." >&2
+	echo "Log in with Claude Code, or in pi: /login  →  Anthropic (Claude Pro/Max)" >&2
+	exit 1
+fi
+
+mkdir -p "$(dirname "$AUTH_PATH")"
+umask 077
+AUTH_PATH="$AUTH_PATH" RAW="$raw" python3 - <<'PY'
+import json, os, sys, time
+from pathlib import Path
+
+path = Path(os.environ["AUTH_PATH"])
+try:
+    data = json.loads(os.environ["RAW"])
+except json.JSONDecodeError as e:
+    print(f"Claude Code credentials are not valid JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+oauth = data.get("claudeAiOauth")
+if not isinstance(oauth, dict):
+    print("Claude Code credentials have no claudeAiOauth entry.", file=sys.stderr)
+    print("Log in with Claude Code, or in pi: /login  →  Anthropic (Claude Pro/Max)", file=sys.stderr)
+    sys.exit(1)
+
+access = oauth.get("accessToken") or ""
+refresh = oauth.get("refreshToken") or ""
+expires = oauth.get("expiresAt")
+refresh_expires = oauth.get("refreshTokenExpiresAt")
+
+if not access or not refresh:
+    print("Claude Code OAuth tokens are missing or cleared.", file=sys.stderr)
+    print("Re-login with Claude Code, or in pi: /login  →  Anthropic (Claude Pro/Max)", file=sys.stderr)
+    sys.exit(1)
+
+now_ms = int(time.time() * 1000)
+if isinstance(refresh_expires, (int, float)) and refresh_expires <= now_ms:
+    print("Claude Code refresh token is expired.", file=sys.stderr)
+    print("Re-login with Claude Code, or in pi: /login  →  Anthropic (Claude Pro/Max)", file=sys.stderr)
+    sys.exit(1)
+
+if not isinstance(expires, (int, float)):
+    expires = now_ms + 24 * 3600 * 1000
+
+auth = {}
+if path.exists():
+    auth = json.loads(path.read_text())
+
+entry = {
+    "type": "oauth",
+    "access": access,
+    "refresh": refresh,
+    "expires": int(expires),
+}
+if isinstance(oauth.get("scopes"), list):
+    entry["scopes"] = oauth["scopes"]
+if oauth.get("subscriptionType"):
+    entry["subscriptionType"] = oauth["subscriptionType"]
+
+auth["anthropic"] = entry
+path.write_text(json.dumps(auth, indent=2) + "\n")
+path.chmod(0o600)
+
+age_h = (expires - now_ms) / 3600
+print(f"Synced Claude Pro/Max OAuth credentials into {path}")
+print(f"access token expires in {age_h:.1f}h (subscription={entry.get('subscriptionType', '?')})")
+if age_h < 0:
+    print("Note: access token is expired; Pi will refresh it on first use.")
+PY


### PR DESCRIPTION
## Summary
- Switch Pi `enabledModels` to Claude Sonnet/Opus 5 and GPT-5.6 Sol/Terra (`:high` / `:max`), defaulting to `claude-sonnet-5`
- Document built-in Anthropic (Claude Pro/Max) OAuth in `pi/README.md`
- Add `scripts/build_env/sync_pi_claude_auth.sh` to sync Claude Code Keychain tokens into Pi auth

## Test plan
- [ ] `/reload` or restart Pi, then Ctrl+P shows the 8 Claude/Codex model variants
- [ ] `./scripts/build_env/sync_pi_claude_auth.sh` syncs when Claude Code is logged in
- [ ] `pi auth check --provider anthropic --json` and Codex login succeed for the listed models