### PR TITLE
chore(pi): enable Fugu reasoning and restore Cursor defaults

### DIFF
--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -8,7 +8,14 @@
         {
           "id": "fugu",
           "name": "Sakana Fugu",
-          "reasoning": false,
+          "reasoning": true,
+          "thinkingLevelMap": {
+            "off": null,
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high"
+          },
           "input": [
             "text",
             "image"
@@ -25,7 +32,14 @@
         {
           "id": "fugu-ultra",
           "name": "Sakana Fugu Ultra",
-          "reasoning": false,
+          "reasoning": true,
+          "thinkingLevelMap": {
+            "off": null,
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high"
+          },
           "input": [
             "text",
             "image"

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,8 +1,11 @@
 {
-  "defaultProvider": "anthropic",
-  "defaultModel": "claude-sonnet-5",
+  "defaultProvider": "cursor",
+  "defaultModel": "grok-4.5",
   "defaultThinkingLevel": "high",
   "enabledModels": [
+    "cursor/composer-2.5-fast",
+    "cursor/grok-4.5:high",
+    "cursor/grok-4.5-fast:high",
     "anthropic/claude-sonnet-5:high",
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
@@ -10,7 +13,9 @@
     "openai-codex/gpt-5.6-sol:high",
     "openai-codex/gpt-5.6-sol:max",
     "openai-codex/gpt-5.6-terra:high",
-    "openai-codex/gpt-5.6-terra:max"
+    "openai-codex/gpt-5.6-terra:max",
+    "sakana-ai-console/fugu:high",
+    "sakana-ai-console/fugu-ultra:high"
   ],
   "theme": "dark",
   "defaultProjectTrust": "ask",


### PR DESCRIPTION
## Summary
- Enable reasoning for `fugu` / `fugu-ultra` with `thinkingLevelMap` fixed to `high` only
- Add Cursor (`composer-2.5-fast`, `grok-4.5`, `grok-4.5-fast`) and Fugu models to `enabledModels`
- Restore default to `cursor/grok-4.5`

## Verification
- Validated `pi/agent/models.json` and `pi/agent/settings.json` as JSON