### PR TITLE
chore(agents): require fd/rg/etc. as MUST across all agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,20 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 dotfiles repository for macOS/WSL2 development environment. Uses devbox for tool management, dpp.vim (TypeScript/Deno) for Neovim plugin management, and jujutsu (jj) as git-compatible VCS.
 
+## Required Tools (MUST)
+
+Hard requirements for every agent in this environment (not Pi-only). Canonical copy: `claude/rules/required-tools.md`.
+
+- MUST use `fd` for file and directory discovery. Do NOT use `find`. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Exception: POSIX-only environments where `fd` is unavailable.
+- MUST use `rg` for text/code search. Do NOT use recursive `grep`.
+- MUST use `jq` / `yq` for JSON/YAML inspection and transformation. Do NOT hand-parse with ad-hoc shell when `jq`/`yq` can do it.
+- MUST use `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
+- MUST use `sd` for simple literal/regex replacements in shell workflows. Use precise edit tools for small source-file edits.
+- MUST use `taplo` for TOML formatting and validation.
+- MUST use `shellcheck` and `shfmt` for shell script validation and formatting.
+- MUST prefer non-interactive, machine-readable commands in automated agent workflows. Do NOT use interactive tools such as `fzf` unless the user explicitly requests them.
+- MUST NOT re-read the same vendor bundle (`node_modules/**/dist/*.mjs` 等) or large file across multiple turns in one session; once read, note the relevant API/lines and reuse that instead of reading again.
+
 ## Commands
 
 ### Environment Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 dotfiles repository for macOS/WSL2 development environment. Uses devbox for tool management, dpp.vim (TypeScript/Deno) for Neovim plugin management, and jujutsu (jj) as git-compatible VCS.
 
+## Required Tools (MUST)
+
+Hard requirements for every agent in this environment (not Pi-only). Canonical copy: `claude/rules/required-tools.md` (also loaded via `~/.claude/rules/`).
+
+- MUST use `fd` for file and directory discovery. Do NOT use `find`. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Exception: POSIX-only environments where `fd` is unavailable.
+- MUST use `rg` for text/code search. Do NOT use recursive `grep`.
+- MUST use `jq` / `yq` for JSON/YAML inspection and transformation. Do NOT hand-parse with ad-hoc shell when `jq`/`yq` can do it.
+- MUST use `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
+- MUST use `sd` for simple literal/regex replacements in shell workflows. Use precise edit tools for small source-file edits.
+- MUST use `taplo` for TOML formatting and validation.
+- MUST use `shellcheck` and `shfmt` for shell script validation and formatting.
+- MUST prefer non-interactive, machine-readable commands in automated agent workflows. Do NOT use interactive tools such as `fzf` unless the user explicitly requests them.
+- MUST NOT re-read the same vendor bundle (`node_modules/**/dist/*.mjs` 等) or large file across multiple turns in one session; once read, note the relevant API/lines and reuse that instead of reading again.
+
 ## Commands
 
 ### Environment Setup

--- a/antigravity/AGENTS.md
+++ b/antigravity/AGENTS.md
@@ -4,6 +4,14 @@
 
 Claude Codeのサブエージェントとして動作。単独使用は想定しない。
 
+## Required Tools (MUST)
+
+Hard requirements (not preferences). Canonical: `~/.claude/rules/required-tools.md`.
+
+- MUST use `fd` (NOT `find`), `rg` (NOT recursive `grep`), `jq`/`yq`, `ast-grep`, `sd`, `taplo`, `shellcheck`/`shfmt`.
+- MUST use non-interactive machine-readable commands; do NOT use `fzf` unless the user asks.
+- Exception only when the required tool is unavailable.
+
 ## 得意領域
 
 - 大規模コンテキストが必要な調査

--- a/antigravity/instructions.md
+++ b/antigravity/instructions.md
@@ -9,5 +9,8 @@
 - 最新のトレンド・ライブラリ情報
 - ドキュメントの比較・要約
 
+## Required Tools (MUST)
+- Hard requirements: `fd` not `find`, `rg` not recursive `grep`, plus `jq`/`yq`, `ast-grep`, `sd`, `taplo`, `shellcheck`/`shfmt`. Canonical: `~/.claude/rules/required-tools.md`.
+
 ## Output
 - 調査結果は `~/.claude/docs/research/` に保存を推奨

--- a/claude/rules/required-tools.md
+++ b/claude/rules/required-tools.md
@@ -1,0 +1,13 @@
+# Required Tools Rule (MUST)
+
+These are hard requirements for every agent (Claude Code, Pi, Codex, Antigravity/agy, Cursor, etc.), not preferences. Do not use the legacy alternatives when the required tool is available.
+
+- MUST use `fd` for file and directory discovery. Do NOT use `find`. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Exception: POSIX-only environments where `fd` is unavailable.
+- MUST use `rg` for text/code search. Do NOT use recursive `grep`.
+- MUST use `jq` / `yq` for JSON/YAML inspection and transformation. Do NOT hand-parse with ad-hoc shell when `jq`/`yq` can do it.
+- MUST use `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
+- MUST use `sd` for simple literal/regex replacements in shell workflows. Use precise edit tools for small source-file edits.
+- MUST use `taplo` for TOML formatting and validation.
+- MUST use `shellcheck` and `shfmt` for shell script validation and formatting.
+- MUST prefer non-interactive, machine-readable commands in automated agent workflows. Do NOT use interactive tools such as `fzf` unless the user explicitly requests them.
+- MUST NOT re-read the same vendor bundle (`node_modules/**/dist/*.mjs` 等) or large file across multiple turns in one session; once read, note the relevant API/lines and reuse that instead of reading again. Re-reads compound conversation history and inflate cached input tokens on every subsequent request.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -4,6 +4,14 @@
 
 Claude Codeのサブエージェントとして動作。単独使用は想定しない。
 
+## Required Tools (MUST)
+
+Hard requirements (not preferences). Canonical: `~/.claude/rules/required-tools.md`.
+
+- MUST use `fd` (NOT `find`), `rg` (NOT recursive `grep`), `jq`/`yq`, `ast-grep`, `sd`, `taplo`, `shellcheck`/`shfmt`.
+- MUST use non-interactive machine-readable commands; do NOT use `fzf` unless the user asks.
+- Exception only when the required tool is unavailable.
+
 ## 得意領域
 
 - コード実装（auto-editモード: ファイル編集自動、コマンドは確認）

--- a/codex/instructions.md
+++ b/codex/instructions.md
@@ -6,3 +6,6 @@
 
 ## Role
 - コード実装（auto-editモード）
+
+## Required Tools (MUST)
+- Hard requirements: `fd` not `find`, `rg` not recursive `grep`, plus `jq`/`yq`, `ast-grep`, `sd`, `taplo`, `shellcheck`/`shfmt`. Canonical: `~/.claude/rules/required-tools.md`.

--- a/pi/agent/AGENTS.md
+++ b/pi/agent/AGENTS.md
@@ -2,17 +2,19 @@
 
 This file provides global instructions for Pi Coding Agent sessions.
 
-## Tool Preferences
+## Required Tools (MUST)
 
-- Prefer `fd` over `find` for file and directory discovery. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Use `find` only when POSIX-specific behavior is required or `fd` is unavailable.
-- Prefer `rg` over recursive `grep` for text/code search.
-- Prefer `jq` and `yq` for JSON/YAML inspection and transformation.
-- Prefer `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
-- Prefer `sd` for simple literal/regex replacements in shell workflows; use precise edit tools for small source-file edits.
-- Prefer `taplo` for TOML formatting and validation.
-- Prefer `shellcheck` and `shfmt` for shell script validation and formatting.
-- Prefer non-interactive, machine-readable commands in automated agent workflows; avoid interactive tools such as `fzf` unless explicitly requested.
-- Avoid re-reading the same vendor bundle (`node_modules/**/dist/*.mjs` 等) or large file across multiple turns in one session; once read, note the relevant API/lines and reuse that instead of reading again. Re-reads compound conversation history and inflate cached input tokens on every subsequent request.
+These are hard requirements for every agent (Pi and others), not preferences. Canonical shared rule: `claude/rules/required-tools.md`. Do not use the legacy alternatives when the required tool is available.
+
+- MUST use `fd` for file and directory discovery. Do NOT use `find`. Examples: `fd PATTERN`, `fd -e ts`, `fd -t f PATTERN`, `fd -H -I PATTERN`. Exception: POSIX-only environments where `fd` is unavailable.
+- MUST use `rg` for text/code search. Do NOT use recursive `grep`.
+- MUST use `jq` / `yq` for JSON/YAML inspection and transformation. Do NOT hand-parse with ad-hoc shell when `jq`/`yq` can do it.
+- MUST use `ast-grep` for syntax-aware code search and codemods when plain text search may be unsafe.
+- MUST use `sd` for simple literal/regex replacements in shell workflows. Use precise edit tools for small source-file edits.
+- MUST use `taplo` for TOML formatting and validation.
+- MUST use `shellcheck` and `shfmt` for shell script validation and formatting.
+- MUST prefer non-interactive, machine-readable commands in automated agent workflows. Do NOT use interactive tools such as `fzf` unless the user explicitly requests them.
+- MUST NOT re-read the same vendor bundle (`node_modules/**/dist/*.mjs` 等) or large file across multiple turns in one session; once read, note the relevant API/lines and reuse that instead of reading again. Re-reads compound conversation history and inflate cached input tokens on every subsequent request.
 
 ## AI Agent Routing
 


### PR DESCRIPTION
## Summary
- Promote former Pi “tool preferences” to hard MUST requirements shared by all agents
- Add canonical rule at `claude/rules/required-tools.md` and mirror into root/`CLAUDE.md`/`pi`/`codex`/`antigravity` agent docs

## Test plan
- [ ] Confirm `~/.claude/rules/required-tools.md` is present via the Claude symlink
- [ ] Spot-check that Claude Code, Pi, Codex, and Antigravity each load the Required Tools section
- [ ] No `pi/agent/settings.json` churn included