### PR TITLE
fix(fish): Ctrl+S/Ctrl+Tのghq-fzfキーバインドが発火しない問題を修正

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -24,10 +24,12 @@ set -gx DFT_DISPLAY side-by-side-show-both
 # API keys (Bitwarden→Keychainキャッシュ。更新は sync-key、新規は add-key が下行に自動追記)
 # add-key が新規アイテムを作る Bitwarden フォルダ
 set -gx BW_KEY_FOLDER "env"
-set -l api_key_items fugu-api-key firecrawl-api-key devin-api-key
-for item in $api_key_items
-    set -l val (security find-generic-password -s $item -w 2>/dev/null)
-    test -n "$val"; and set -gx (string upper (string replace -a - _ $item)) $val
+if command -q security
+    set -l api_key_items fugu-api-key firecrawl-api-key devin-api-key
+    for item in $api_key_items
+        set -l val (security find-generic-password -s $item -w 2>/dev/null)
+        test -n "$val"; and set -gx (string upper (string replace -a - _ $item)) $val
+    end
 end
 
 # devbox

--- a/fish/functions/fish_user_key_bindings.fish
+++ b/fish/functions/fish_user_key_bindings.fish
@@ -12,22 +12,22 @@ function fish_user_key_bindings --description 'Set custom key bindings and keep 
     end
 
     # ghq-fzf: Ctrl+S (BEAKL: sはホームロー下方向)
-    # 末尾の repaint で ESC キャンセル時もプロンプトを再描画する
+    # repaint は関数内部で commandline -f repaint 済み（別トークンで渡すとbindが発火しない環境があるため単一コマンドのみ渡す）
     if functions -q ghq-fzf
-        bind \cs ghq-fzf repaint
-        bind -M insert \cs ghq-fzf repaint
+        bind \cs ghq-fzf
+        bind -M insert \cs ghq-fzf
     end
 
     # ghq-fzf-jj: Ctrl+T (BEAKL: tはホームロー上方向)
     if functions -q ghq-fzf-jj
-        bind \ct ghq-fzf-jj repaint
-        bind -M insert \ct ghq-fzf-jj repaint
+        bind \ct ghq-fzf-jj
+        bind -M insert \ct ghq-fzf-jj
     end
 
     # fzf-file-widget: Ctrl+G
     if functions -q fzf-file-widget
-        bind \cg fzf-file-widget repaint
-        bind -M insert \cg fzf-file-widget repaint
+        bind \cg fzf-file-widget
+        bind -M insert \cg fzf-file-widget
     end
 
     if functions -q fancy-ctrl-z


### PR DESCRIPTION
## Summary
- `bind \cs ghq-fzf repaint` のように関数名と `repaint` を別トークンで渡す形式が、このfish環境ではキー押下時に発火しなかった。`fzf` 本体のバインド（`bind \cr fzf-history-widget`）が単一トークンだったことから切り分け、`ghq-fzf` / `ghq-fzf-jj` / `fzf-file-widget` の3バインドすべてを単一トークンに修正
- 各関数は内部で既に `commandline -f repaint` を呼んでいるため、外側の `repaint` トークンは元々冗長だった
- おまけ: WSL2で `config.fish` 起動時に、macOS専用の `security` コマンドが無く `Bitwarden→Keychain` キャッシュ読み込みが失敗していたのを `command -q security` でガード

## Test plan
- [x] 新規タブでCtrl+Sを押して `ghq-fzf` が起動することを確認
- [x] Ctrl+Tを押して `ghq-fzf-jj` が起動することを確認
- [x] `fish -c "source ~/.config/fish/config.fish; echo OK"` でsourceエラーが出ないことを確認