### PR TITLE
feat(fish): use Bitwarden SSH agent socket as SSH_AUTH_SOCK on WSL

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -21,6 +21,12 @@ set -gx EDITOR nvim
 set -gx TERM xterm-256color
 set -gx DFT_DISPLAY side-by-side-show-both
 
+# WSL: Bitwarden SSH agent ブリッジ socket を SSH_AUTH_SOCK に設定
+# IdentityAgent を参照しないツール(jj/git)からも agent を使えるようにする
+if test -S ~/.bitwarden-ssh-agent.sock
+    set -gx SSH_AUTH_SOCK ~/.bitwarden-ssh-agent.sock
+end
+
 # API keys (Bitwarden→Keychainキャッシュ。更新は sync-key、新規は add-key が下行に自動追記)
 # add-key が新規アイテムを作る Bitwarden フォルダ
 set -gx BW_KEY_FOLDER "env"


### PR DESCRIPTION
## Summary
- WSL で `~/.bitwarden-ssh-agent.sock` があるときのみ `SSH_AUTH_SOCK` に設定
- `IdentityAgent` を参照しないツール(jj/git)からも Bitwarden SSH agent を使えるようにする
- socket 存在時のみ発火するので macOS には影響なし

## Verification
- `fish -n fish/config.fish` (syntax ok)
- `fish -c 'echo $SSH_AUTH_SOCK'` で socket パスが入ることを確認
- `ssh -T git@github.com` で認証成功を確認