### PR TITLE
chore(pi): keep only grok-4.6-fast

### DIFF
--- a/pi/agent/model-roles.json
+++ b/pi/agent/model-roles.json
@@ -2,7 +2,7 @@
   "description": "Single source of truth for model IDs. Skills resolve roles via resolve-model.sh; run --apply to sync enabledModels into settings.json. defaultModel is runtime state owned by Pi and is intentionally not managed here. parallel-review picks a tier from reviewLevels (1=light, 2=standard, 3=deep); tiers change precision (model/thinking) only. Each reviewer's timeout is computed from patch size as base + perKb*KB (capped by the skill), so time scales with the change, not the tier. single-reviewer skills use the review.* roles, which are defined separately and may differ from a tier's models.",
   "enabledModels": [
     "cursor/composer-2.5-fast",
-    "cursor/grok-4.6",
+    "cursor/grok-4.6-fast",
     "cursor/grok-4.6-fast:high",
     "anthropic/claude-sonnet-5:high",
     "anthropic/claude-sonnet-5:max",
@@ -17,8 +17,8 @@
   ],
   "roles": {
     "review.cursor": {
-      "pi": "cursor/grok-4.6",
-      "label": "Cursor Grok 4.6"
+      "pi": "cursor/grok-4.6-fast",
+      "label": "Cursor Grok 4.6 Fast"
     },
     "review.codex": {
       "pi": "openai-codex/gpt-5.6-terra:high",

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,10 +1,10 @@
 {
   "defaultProvider": "cursor",
-  "defaultModel": "grok-4.6",
+  "defaultModel": "grok-4.6-fast",
   "defaultThinkingLevel": "high",
   "enabledModels": [
     "cursor/composer-2.5-fast",
-    "cursor/grok-4.6",
+    "cursor/grok-4.6-fast",
     "cursor/grok-4.6-fast:high",
     "anthropic/claude-sonnet-5:high",
     "anthropic/claude-sonnet-5:max",


### PR DESCRIPTION
## Summary
- Cursor Grok から通常の `grok-4.6` を外し、`grok-4.6-fast` だけ残す
- `review.cursor` を `cursor/grok-4.6-fast` に切り替え、`enabledModels` も fast / fast:high に揃える

## Test plan
- [ ] `bash pi/agent/resolve-model.sh --check` が通る
- [ ] `bash pi/agent/resolve-model.sh review.cursor` が `cursor/grok-4.6-fast` を返す
- [ ] Pi のモデル一覧に通常の grok-4.6 が出ない