### PR TITLE
chore: add pre-push hook to run test suite

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Runs the test suite before pushing. Aborts the push on failure.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+exec "$REPO_ROOT/scripts/run_tests.sh"

--- a/SETUP.md
+++ b/SETUP.md
@@ -54,6 +54,12 @@ chmod +x ./scripts/build_env/create_symlink.sh
 - nvim, fish, gitconfig等の基本設定
 - claude/, codex/, antigravity/ のAI Tools設定
 
+あわせて `create_symlink.sh` が git の `core.hooksPath` を `.githooks` に設定し、
+push 前に `scripts/run_tests.sh`（Deno + bats）が走る pre-push hook が有効になる。
+
+> **注意**: git hooks は `git push` でのみ発火する。`jj git push` は git hooks を実行しないため、
+> jj で push する場合は事前に `./scripts/run_tests.sh` を手動で実行すること。
+
 ## devboxツールのインストール
 
 `setup_fish.sh`実行後（devbox.jsonのシンボリックリンク作成後）：

--- a/scripts/build_env/create_symlink.sh
+++ b/scripts/build_env/create_symlink.sh
@@ -195,3 +195,6 @@ elif [ -e "${HUNK_SKILL_DEST}" ]; then
   mv "${HUNK_SKILL_DEST}" "$HOME/.agents/skill-backups/hunk-review.backup-$(date +%Y%m%d%H%M%S)"
 fi
 ln -sfn "${HUNK_SKILL_SRC}" "${HUNK_SKILL_DEST}"
+
+# git hooks: run the test suite before every push (.githooks/pre-push)
+git -C "${BASE_DIR}" config --local core.hooksPath .githooks

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run all repo tests (Deno + bats). Used by the git pre-push hook and manually.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_ROOT"
+
+fail=0
+
+# Required tools: missing any of them is a failure, not a silent skip,
+# otherwise the pre-push hook would let untested code through.
+for tool in deno bats fd; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "missing required tool: $tool" >&2
+		exit 1
+	fi
+done
+
+run() {
+	local label=$1
+	shift
+	echo "==> $label"
+	if ! "$@"; then
+		echo "FAILED: $label" >&2
+		fail=1
+	fi
+}
+
+# Deno tests (pi extensions)
+run "deno test (pi/agent)" deno test --allow-read --quiet pi/agent/tests/
+
+# bats tests
+mapfile -d '' -t bats_files < <(fd -H -e bats -0 . pi/agent/tests .agents/skills)
+if [[ ${#bats_files[@]} -eq 0 ]]; then
+	echo "no bats tests found" >&2
+	exit 1
+fi
+for f in "${bats_files[@]}"; do
+	run "bats $f" bats "$f"
+done
+
+if [[ $fail -ne 0 ]]; then
+	echo "Tests failed." >&2
+	exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- push 前に Deno + bats のテストを走らせる git pre-push hook を追加
- `scripts/run_tests.sh`: Deno テスト(`pi/agent/tests/`)と全 bats テストを一括実行。必須ツール(`deno`/`bats`/`fd`)の欠如や bats 0 件を検出して `exit 1`（テスト未実行での push を防止）
- `.githooks/pre-push`: 上記スクリプトを呼び、失敗時は push を中断
- `scripts/build_env/create_symlink.sh`: setup 時に `core.hooksPath` を `.githooks` へ設定
- `SETUP.md`: フック説明と、`jj git push` は git hooks を実行しない旨の注意を追記

## Verification
- `shellcheck` / `shfmt` パス
- `./scripts/run_tests.sh`: 全 71 テスト通過
- deno 欠如シミュレーション: `missing required tool: deno` → exit 1

## Note
- git hooks は `git push` でのみ発火。jj で push する場合は事前に `./scripts/run_tests.sh` を手動実行すること