### PR TITLE
docs: WSL の Windows Terminal で Shift+Enter が pi の改行になる手順を残す

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -140,6 +140,12 @@ Denoのキャッシュが原因で上手くインストールできないとき�
 
 ## WSL2固有の設定
 
+### Windows Terminal: Shift+Enter → pi 改行
+
+Mac Ghostty と同じ `Shift+Enter` で pi に改行を入れるため、Windows Terminal
+の `settings.json` で `shift+enter` を `\u001b[13;2u` にリマップする。
+詳細は `pi/README.md` の「Shift+Enter (WSL / Windows Terminal)」を参照。
+
 ### xsel
 ```bash
 sudo apt install xsel

--- a/pi/README.md
+++ b/pi/README.md
@@ -40,6 +40,27 @@ PI_CODING_AGENT_DIR=$PWD/pi/agent pi --list-models
 PI_CODING_AGENT_DIR=$PWD/pi/agent pi
 ```
 
+## Shift+Enter (WSL / Windows Terminal)
+
+Mac Ghostty sends Kitty keyboard protocol for `Shift+Enter`, so pi inserts a
+newline. Windows Terminal does not, unless you remap it.
+
+In Windows Terminal `settings.json` (`Ctrl+Shift+,` → Open JSON file), bind
+`shift+enter` to Kitty CSI u `ESC[13;2u`:
+
+```json
+{
+  "command": { "action": "sendInput", "input": "\u001b[13;2u" },
+  "keys": "shift+enter"
+}
+```
+
+Do **not** send `\u001b\r` (ESC+CR). Pi treats that as a different chord, so
+`Shift+Enter` will not insert a newline.
+
+Windows Terminal usually reloads `settings.json` automatically. If it does not,
+fully close and reopen the terminal. Fallback without this remap: `Ctrl+J`.
+
 ## Model setup
 
 Use Pi's built-in subscription flow when possible:


### PR DESCRIPTION
## Summary
- Mac Ghostty と同じ `Shift+Enter` で pi に改行を入れるため、Windows Terminal が Kitty CSI u (`ESC[13;2u`) を送る設定を手順として残した。
- `settings.json` 本体は git 管理せず、`pi/README.md` と `SETUP.md` にリマップ方法だけを書いた。

## Test plan
- [ ] Windows Terminal の `settings.json` で `shift+enter` を `\u001b[13;2u` にリマップする
- [ ] pi で `Shift+Enter` が改行、`Enter` が送信になることを確認する
- [ ] 反映されない場合は Windows Terminal を再起動して再確認する