### PR TITLE
pi: repo memory に review_memory tool を追加して自然文で整理する

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -225,6 +225,7 @@ Configured by `settings.json` via `extensions/*.ts` and npm packages.
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
+| `repo-memory-local.ts`          | Local-only repo memory: `recall_memory` / `remember` / `review_memory` tools + `/repo-memory-review` command. |
 | `git:…/pi-cursor@fix/goaway-after-turn-ended` | Cursor models via OAuth; silences post-turn GOAWAY (PR #4). |
 
 Reload after editing extensions:
@@ -243,6 +244,32 @@ model at turn settlement; manual `/model` selection cancels auto-restore. Use
 `/auto-fugu on|off|status` to toggle automatic routing; an
 empty `/auto-fugu` toggles ON/OFF. After editing extensions or routing logic,
 run `/reload` (core `node_modules` changes still require a Pi restart).
+
+### Repo memory
+
+`repo-memory-local.ts` stores durable, repo-specific notes **outside** the repo
+(`~/.local/state/pi-repo-memory/<repo>-<hash>/memory.md`, `chmod 600`, never
+versioned). A small index is injected at `session_start`.
+
+- `recall_memory` — read saved notes (optional substring filter).
+- `remember` — append one durable note (deduped; `[topic]` tag optional).
+- `review_memory` — **agent-callable** consolidation tool. Saying e.g. 「メモリ整理して」
+  triggers it: it rewrites `memory.md` in one LLM pass (using the current model)
+  and keeps a `.bak` backup.
+
+The same consolidation is also available as a user slash command (interactive,
+asks to confirm before overwriting):
+
+```text
+/repo-memory-review
+```
+
+Both paths consolidate `memory.md` in **one LLM pass** (dedupe, prune
+obsolete/one-off items, regroup under `## <topic>` headings, each bullet ≤ 220
+chars, timestamps dropped) and keep a `.bak` backup. The `review_memory` tool
+overwrites directly (no confirm) since `.bak` makes it recoverable; the slash
+command asks to confirm and reports before/after note counts. The extension also
+nudges (session_start index) to consolidate once memory grows past ~8KB.
 
 ## Skills
 

--- a/pi/agent/extensions/repo-memory-local.ts
+++ b/pi/agent/extensions/repo-memory-local.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { complete } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { createHash } from "node:crypto";
@@ -145,6 +145,7 @@ export default function repoMemoryLocal(pi: ExtensionAPI) {
     promptGuidelines: [
       "Use recall_memory near the start of a non-trivial task to load repo-specific gotchas, commands, and decisions saved from prior sessions.",
       "Treat recall_memory output as hints; current code and project instructions still win.",
+      "When recalled notes look stale, duplicated, or contradict current code, use review_memory to consolidate repo memory.",
     ],
     parameters: Type.Object({
       query: Type.Optional(
@@ -190,6 +191,7 @@ export default function repoMemoryLocal(pi: ExtensionAPI) {
     promptGuidelines: [
       "Use remember when you learn a durable repo-specific fact worth reusing later: a non-obvious command that worked, a gotcha, a design decision, or a repo convention.",
       "Do not use remember for secrets, credentials, one-off progress, or generic advice.",
+      "When repo memory has grown large or accumulated overlapping notes, use review_memory to consolidate it (dedupe/prune).",
     ],
     parameters: Type.Object({
       note: Type.String({ description: "Durable repo-specific note to save" }),
@@ -245,71 +247,155 @@ export default function repoMemoryLocal(pi: ExtensionAPI) {
     },
   });
 
-  pi.registerCommand("repo-memory-review", {
-    description: "Consolidate repo memory via one LLM pass (dedupe, prune, regroup)",
-    handler: async (_args, ctx) => {
-      let rawContent: string;
+  // Shared consolidation used by both the /repo-memory-review command (interactive,
+  // with confirm) and the review_memory tool (agent-callable, e.g. "メモリ整理して").
+  type ConsolidateResult =
+    | { status: "empty" }
+    | { status: "no-model" }
+    | { status: "no-auth"; error: string }
+    | { status: "no-output" }
+    | { status: "ready"; rawContent: string; curated: string; beforeCount: number; afterCount: number };
+
+  const consolidateMemoryText = async (ctx: ExtensionContext): Promise<ConsolidateResult> => {
+    let rawContent: string;
+    try {
+      rawContent = await readFile(memoryPath, "utf8");
+    } catch {
+      return { status: "empty" };
+    }
+    const text = rawContent.trim();
+    if (!text) return { status: "empty" };
+    if (!ctx.model) return { status: "no-model" };
+
+    const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model);
+    if (!auth.ok || !auth.apiKey) {
+      return { status: "no-auth", error: auth.error ?? "API key not available" };
+    }
+
+    const response = await complete(
+      ctx.model,
+      {
+        systemPrompt: REVIEW_SYSTEM,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: `<memory>${text}</memory>` }],
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
+    );
+
+    const curated = response.content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("\n")
+      .trim();
+    if (!curated) return { status: "no-output" };
+
+    return {
+      status: "ready",
+      rawContent,
+      curated,
+      beforeCount: countBullets(text),
+      afterCount: countBullets(curated),
+    };
+  };
+
+  const applyConsolidation = async (rawContent: string, curated: string) => {
+    await mkdir(join(memoryPath, ".."), { recursive: true });
+    await writeFile(`${memoryPath}.bak`, rawContent, { encoding: "utf8", mode: 0o600 });
+    const curatedText = curated.endsWith("\n") ? curated : `${curated}\n`;
+    await writeFile(memoryPath, curatedText, { encoding: "utf8", mode: 0o600 });
+    await chmod(memoryPath, 0o600).catch(() => {});
+    // Reflect the consolidated memory in the current session's injected index.
+    indexSnapshot = buildMemoryIndex(curated);
+  };
+
+  pi.registerTool({
+    name: "review_memory",
+    label: "Consolidate Repo Memory",
+    description:
+      "Consolidates this repository's local memory in one LLM pass (dedupe, prune, regroup) and keeps a .bak backup.",
+    promptSnippet: "Consolidate repo memory (dedupe, prune, regroup); keeps a .bak backup",
+    promptGuidelines: [
+      'Use review_memory when the user asks to clean up or consolidate repo memory (e.g. "メモリ整理して"), or when memory has grown large or drifted. It rewrites memory.md and keeps a .bak backup.',
+    ],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const result = await consolidateMemoryText(ctx);
+      if (result.status === "empty") {
+        return { content: [{ type: "text", text: "No repo memory to consolidate." }] };
+      }
+      if (result.status === "no-model") {
+        return {
+          content: [{ type: "text", text: "No model selected; cannot consolidate repo memory." }],
+        };
+      }
+      if (result.status === "no-auth") {
+        return { content: [{ type: "text", text: `Cannot consolidate repo memory: ${result.error}` }] };
+      }
+      if (result.status === "no-output") {
+        return {
+          content: [{ type: "text", text: "Consolidation produced no output; memory left unchanged." }],
+        };
+      }
+
       try {
-        rawContent = await readFile(memoryPath, "utf8");
-      } catch {
-        ctx.ui.notify("No repo memory to review.", "info");
-        return;
-      }
-
-      const text = rawContent.trim();
-      if (!text) {
-        ctx.ui.notify("No repo memory to review.", "info");
-        return;
-      }
-
-      if (!ctx.model) {
-        ctx.ui.notify("No model selected", "warning");
-        return;
-      }
-
-      const auth = await ctx.modelRegistry.getApiKeyAndHeaders(ctx.model);
-      if (!auth.ok || !auth.apiKey) {
-        ctx.ui.notify(auth.error ?? "API key not available", "warning");
-        return;
+        await applyConsolidation(result.rawContent, result.curated);
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Failed to write consolidated memory: ${errorMessage(error)}` }],
+        };
       }
 
       if (ctx.hasUI) {
+        ctx.ui.notify(
+          `Repo memory consolidated: ${result.beforeCount} → ${result.afterCount} notes (.bak saved)`,
+          "info",
+        );
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Repo memory consolidated: ${result.beforeCount} → ${result.afterCount} notes. A .bak backup was kept.`,
+          },
+        ],
+      };
+    },
+  });
+
+  pi.registerCommand("repo-memory-review", {
+    description: "Consolidate repo memory via one LLM pass (dedupe, prune, regroup)",
+    handler: async (_args, ctx) => {
+      if (ctx.hasUI) {
         ctx.ui.notify("Reviewing repo memory...", "info");
       }
-
-      const response = await complete(
-        ctx.model,
-        {
-          systemPrompt: REVIEW_SYSTEM,
-          messages: [
-            {
-              role: "user",
-              content: [{ type: "text", text: `<memory>${text}</memory>` }],
-              timestamp: Date.now(),
-            },
-          ],
-        },
-        { apiKey: auth.apiKey, headers: auth.headers, env: auth.env },
-      );
-
-      const curated = response.content
-        .filter((c) => c.type === "text")
-        .map((c) => c.text)
-        .join("\n")
-        .trim();
-
-      if (!curated) {
+      const result = await consolidateMemoryText(ctx);
+      if (result.status === "empty") {
+        ctx.ui.notify("No repo memory to review.", "info");
+        return;
+      }
+      if (result.status === "no-model") {
+        ctx.ui.notify("No model selected", "warning");
+        return;
+      }
+      if (result.status === "no-auth") {
+        ctx.ui.notify(result.error, "warning");
+        return;
+      }
+      if (result.status === "no-output") {
         ctx.ui.notify("Review produced no output.", "warning");
         return;
       }
 
-      const beforeCount = countBullets(text);
-      const afterCount = countBullets(curated);
-
       if (ctx.hasUI) {
         const confirmed = await ctx.ui.confirm(
           "Apply memory review?",
-          `Before: ${beforeCount} notes → After: ${afterCount} notes. Overwrite memory.md? A .bak backup is kept.`,
+          `Before: ${result.beforeCount} notes → After: ${result.afterCount} notes. Overwrite memory.md? A .bak backup is kept.`,
         );
         if (!confirmed) {
           ctx.ui.notify("Cancelled", "info");
@@ -318,17 +404,10 @@ export default function repoMemoryLocal(pi: ExtensionAPI) {
       }
 
       try {
-        await mkdir(join(memoryPath, ".."), { recursive: true });
-        await writeFile(`${memoryPath}.bak`, rawContent, { encoding: "utf8", mode: 0o600 });
-        const curatedText = curated.endsWith("\n") ? curated : `${curated}\n`;
-        await writeFile(memoryPath, curatedText, { encoding: "utf8", mode: 0o600 });
-        await chmod(memoryPath, 0o600).catch(() => {});
-
-        indexSnapshot = buildMemoryIndex(curated);
-
+        await applyConsolidation(result.rawContent, result.curated);
         if (ctx.hasUI) {
           ctx.ui.notify(
-            `Repo memory reviewed: ${beforeCount} → ${afterCount} notes (.bak saved)`,
+            `Repo memory reviewed: ${result.beforeCount} → ${result.afterCount} notes (.bak saved)`,
             "info",
           );
         }


### PR DESCRIPTION
## 概要
- これまで repo memory の整理は `/repo-memory-review` スラッシュコマンド専用で、agent（LLM）からは呼べなかった。「メモリ整理して」のような自然文で起動できないのが不便だった。
- agent が呼べる `review_memory` tool を追加し、自然文からメモリ整理（dedupe / prune / regroup）を実行できるようにする。

## 変更内容
- 整理ロジックを共有関数 `consolidateMemoryText` / `applyConsolidation` に切り出し、既存コマンドと新 tool で再利用（重複排除）。
- `review_memory` tool を新設。`promptGuidelines` に「『メモリ整理して』等で頼まれたら使う」と明記。1パスで整理し、`.bak` を残して `memory.md` を上書き（確認なし。`.bak` で復元可能）。
- `recall_memory` / `remember` の guideline を「`review_memory` を使う」に更新。
- `/repo-memory-review` コマンドは確認付きのまま維持（共有関数を使うよう内部だけ変更）。
- `pi/README.md` を実態（agent から `review_memory` で呼べる）に合わせて更新。

```mermaid
flowchart LR
  nl["自然文: メモリ整理して"] --> tool["review_memory tool"]
  cmd["/repo-memory-review (確認あり)"] --> shared
  tool --> shared["consolidateMemoryText / applyConsolidation"]
  shared --> bak[".bak 退避 → memory.md 上書き"]
```

## 確認
- [x] `deno check`：新規エラーは既存 tool と同型の環境依存 TS2322 が1件のみ（Pi 実行時は esbuild で型除去され無害）。
- [x] `review_memory` を実際に実行し、memory.md が3トピックへ整理され `.bak` が残ることを確認。
- [ ] deno fmt は未適用（元からこのファイルは fmt 非準拠で、整形すると無関係な大量差分になるため既存スタイルを維持）。
- [ ] Pi ランタイム状態の `pi/agent/settings.json` は本 PR に含めない。