### PR TITLE
壊れた playwright スキルの symlink を削除する

### DIFF
--- a/claude/skills/playwright-best-practices
+++ b/claude/skills/playwright-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/playwright-best-practices

--- a/claude/skills/playwright-cli
+++ b/claude/skills/playwright-cli
@@ -1,1 +1,0 @@
-../../.agents/skills/playwright-cli


### PR DESCRIPTION
## 概要
- スキル棚卸しで `claude/skills` にデッドリンク2件を発見したため削除する。
- リンク先 `.agents/skills/playwright-best-practices` / `.agents/skills/playwright-cli` の実体が存在せず、参照するとエラーになる状態だった。

## 変更内容
- 削除: `claude/skills/playwright-best-practices`（-> `../../.agents/skills/playwright-best-practices`、実体なし）
- 削除: `claude/skills/playwright-cli`（-> `../../.agents/skills/playwright-cli`、実体なし）

## 確認
- [x] 削除後に `claude/skills` 内へデッドリンクが残っていないことを確認
- [x] `~/.agents/skills`（Pi 実効セット）に playwright 参照は元から無く影響なし
- [ ] 無関係なローカル設定変更（`pi/agent/settings.json`）は本PRに含めない