### PR TITLE
pi の default を fugu にし cursor grok の model ID リネームに追従する

### DIFF
--- a/pi/agent/model-roles.json
+++ b/pi/agent/model-roles.json
@@ -2,8 +2,8 @@
   "description": "Single source of truth for model IDs. Skills resolve roles via resolve-model.sh; run --apply to sync enabledModels into settings.json. defaultModel is runtime state owned by Pi and is intentionally not managed here. parallel-review picks a tier from reviewLevels (1=light, 2=standard, 3=deep); tiers change precision (model/thinking) only. Each reviewer's timeout is computed from patch size as base + perKb*KB (capped by the skill), so time scales with the change, not the tier. single-reviewer skills use the review.* roles, which are defined separately and may differ from a tier's models.",
   "enabledModels": [
     "cursor/composer-2.5-fast",
-    "cursor/grok-4.6-fast",
-    "cursor/grok-4.6-fast:high",
+    "cursor/cursor-grok-4.6-fast",
+    "cursor/cursor-grok-4.6-fast:high",
     "anthropic/claude-sonnet-5:high",
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
@@ -17,7 +17,7 @@
   ],
   "roles": {
     "review.cursor": {
-      "pi": "cursor/grok-4.6-fast",
+      "pi": "cursor/cursor-grok-4.6-fast",
       "label": "Cursor Grok 4.6 Fast"
     },
     "review.codex": {
@@ -49,13 +49,13 @@
       { "pi": "anthropic/claude-sonnet-5:high", "base": 60, "perKb": 2 }
     ],
     "2": [
-      { "pi": "cursor/grok-4.6-fast", "base": 60, "perKb": 3 },
+      { "pi": "cursor/cursor-grok-4.6-fast", "base": 60, "perKb": 3 },
       { "pi": "openai-codex/gpt-5.6-terra:high", "base": 60, "perKb": 2 },
       { "pi": "anthropic/claude-opus-5:high", "base": 60, "perKb": 3 },
       { "pi": "sakana-ai-console/fugu-ultra:high", "base": 180, "perKb": 8 }
     ],
     "3": [
-      { "pi": "cursor/grok-4.6-fast:high", "base": 120, "perKb": 5 },
+      { "pi": "cursor/cursor-grok-4.6-fast:high", "base": 120, "perKb": 5 },
       { "pi": "openai-codex/gpt-5.6-sol:max", "base": 90, "perKb": 3 },
       { "pi": "anthropic/claude-opus-5:max", "base": 90, "perKb": 4 },
       { "pi": "sakana-ai-console/fugu-ultra:high", "base": 180, "perKb": 8 }

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,11 +1,11 @@
 {
-  "defaultProvider": "cursor",
-  "defaultModel": "grok-4.6-fast",
+  "defaultProvider": "sakana-ai-console",
+  "defaultModel": "fugu",
   "defaultThinkingLevel": "high",
   "enabledModels": [
     "cursor/composer-2.5-fast",
-    "cursor/grok-4.6-fast",
-    "cursor/grok-4.6-fast:high",
+    "cursor/cursor-grok-4.6-fast",
+    "cursor/cursor-grok-4.6-fast:high",
     "anthropic/claude-sonnet-5:high",
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",


### PR DESCRIPTION
## 概要
- Cursor 側の Grok モデル ID が `grok-4.6-fast` から `cursor-grok-4.6-fast` にリネームされたため追従する
- Pi の既定を Cursor Grok から Sakana Fugu に切り替える

## 変更内容
- `pi/agent/settings.json`: `defaultProvider` を `cursor` → `sakana-ai-console`、`defaultModel` を `grok-4.6-fast` → `fugu` に変更。`enabledModels` の cursor grok ID をリネーム
- `pi/agent/model-roles.json`: `enabledModels`・`review.cursor` ロール・`reviewLevels` の cursor grok ID をリネーム

## 確認
- [x] `jq empty` で両 JSON の妥当性を確認
- [ ] resolve-model.sh --apply による同期は未実行（enabledModels は手動で整合済み）