### PR TITLE
PiでCodexプランの利用率を確認できるようにする

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -223,6 +223,7 @@ Configured by `settings.json` via `extensions/*.ts` and npm packages.
 | ------------------------------- | -------------------------------------------------------------------- |
 | `local-openai.ts`               | Auto-register LM Studio models from `LM_STUDIO_BASE_URL` at startup. |
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
+| `codex-usage.ts`                | Show ChatGPT Codex plan usage and reset time in Pi's footer. Refresh with `/codex-usage`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
 | `repo-memory-local.ts`          | Local-only repo memory: `recall_memory` / `remember` / `review_memory` tools + `/repo-memory-review` command. |
@@ -233,6 +234,17 @@ Reload after editing extensions:
 ```text
 /reload
 ```
+
+### Codex plan usage
+
+`codex-usage.ts` keeps Pi's built-in footer and adds a compact status such as
+`Codex Pro 7d 0% ↻08/25 14:57` while an `openai-codex` model is selected. It
+reads the subscription quota through the locally authenticated `codex
+app-server`, so Codex CLI must be installed and logged in.
+
+Usage refreshes at session start, after model switches, and after each settled
+agent run. Run `/codex-usage` to force a refresh; automatic failures stay silent
+and clear stale status.
 
 ### Fugu model routing
 

--- a/pi/agent/extensions/codex-usage.ts
+++ b/pi/agent/extensions/codex-usage.ts
@@ -1,0 +1,106 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { formatCodexUsageStatus, queryCodexUsage } from "../lib/codex-usage.ts";
+
+const CODEX_PROVIDER = "openai-codex";
+const STATUS_KEY = "codex-usage";
+
+const isCodexProvider = (ctx: ExtensionContext) =>
+  ctx.model?.provider === CODEX_PROVIDER;
+
+export default function codexUsage(pi: ExtensionAPI) {
+  let refreshId = 0;
+  let controller: AbortController | undefined;
+
+  const clearStatus = (ctx: ExtensionContext) => {
+    if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, undefined);
+  };
+
+  const cancelRefresh = () => {
+    refreshId++;
+    controller?.abort();
+    controller = undefined;
+  };
+
+  const refresh = async (
+    ctx: ExtensionContext,
+    options?: { notify?: boolean },
+  ) => {
+    cancelRefresh();
+    if (!ctx.hasUI) {
+      clearStatus(ctx);
+      return;
+    }
+    if (!isCodexProvider(ctx)) {
+      clearStatus(ctx);
+      return;
+    }
+
+    const currentId = refreshId;
+    const currentController = new AbortController();
+    controller = currentController;
+
+    try {
+      const snapshot = await queryCodexUsage({
+        signal: currentController.signal,
+      });
+      if (currentId !== refreshId) return;
+
+      const status = formatCodexUsageStatus(snapshot);
+      if (ctx.hasUI) {
+        ctx.ui.setStatus(
+          STATUS_KEY,
+          ctx.ui.theme.fg("dim", status),
+        );
+        if (options?.notify) {
+          ctx.ui.notify(`Codex usage: ${status}`, "info");
+        }
+      }
+    } catch {
+      if (currentId !== refreshId) return;
+      clearStatus(ctx);
+      if (options?.notify && ctx.hasUI) {
+        ctx.ui.notify("Codex usage refresh failed", "warning");
+      }
+    } finally {
+      if (currentId === refreshId) controller = undefined;
+    }
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    void refresh(ctx);
+  });
+
+  pi.on("model_select", (_event, ctx) => {
+    void refresh(ctx);
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    void refresh(ctx);
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    cancelRefresh();
+    clearStatus(ctx);
+  });
+
+  pi.registerCommand("codex-usage", {
+    description: "Refresh ChatGPT Codex plan usage shown in the footer",
+    handler: async (_args, ctx) => {
+      if (!isCodexProvider(ctx)) {
+        clearStatus(ctx);
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            "Codex usage is shown only for openai-codex models",
+            "warning",
+          );
+        }
+        return;
+      }
+
+      await refresh(ctx, { notify: true });
+    },
+  });
+}

--- a/pi/agent/lib/codex-usage.ts
+++ b/pi/agent/lib/codex-usage.ts
@@ -1,0 +1,318 @@
+import { spawn } from "node:child_process";
+
+export type RateLimitWindow = {
+  usedPercent: number;
+  windowDurationMins?: number;
+  resetsAt?: number;
+};
+
+export type CodexRateLimitSnapshot = {
+  planType?: string;
+  primary?: RateLimitWindow;
+  secondary?: RateLimitWindow;
+};
+
+export type FormatCodexUsageOptions = {
+  locale?: string;
+  timeZone?: string;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+export type CodexAppServer = {
+  request: (method: string, params?: unknown) => Promise<unknown>;
+  notify: (method: string) => void;
+  close: () => Promise<void>;
+};
+
+export type CreateCodexAppServer = (options: {
+  codexBin: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => CodexAppServer;
+
+export type QueryCodexUsageOptions = {
+  codexBin?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  createAppServer?: CreateCodexAppServer;
+};
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_LOCALE = "en-US";
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseWindow = (value: unknown) => {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.usedPercent !== "number") return undefined;
+  if (!Number.isFinite(value.usedPercent)) return undefined;
+
+  const window: RateLimitWindow = { usedPercent: value.usedPercent };
+  if (
+    typeof value.windowDurationMins === "number" &&
+    Number.isFinite(value.windowDurationMins)
+  ) {
+    window.windowDurationMins = value.windowDurationMins;
+  }
+  if (typeof value.resetsAt === "number" && Number.isFinite(value.resetsAt)) {
+    window.resetsAt = value.resetsAt;
+  }
+  return window;
+};
+
+const parseSnapshot = (value: unknown) => {
+  if (!isRecord(value)) return undefined;
+
+  const snapshot: CodexRateLimitSnapshot = {};
+  if (typeof value.planType === "string") snapshot.planType = value.planType;
+
+  const primary = parseWindow(value.primary);
+  if (primary) snapshot.primary = primary;
+
+  const secondary = parseWindow(value.secondary);
+  if (secondary) snapshot.secondary = secondary;
+
+  if (!snapshot.planType && !snapshot.primary && !snapshot.secondary) {
+    return undefined;
+  }
+  return snapshot;
+};
+
+export const parseRateLimitsReadResponse = (message: unknown) => {
+  if (!isRecord(message) || message.error !== undefined) return undefined;
+  if (!isRecord(message.result)) return undefined;
+
+  const buckets = message.result.rateLimitsByLimitId;
+  if (isRecord(buckets)) {
+    const codex = parseSnapshot(buckets.codex);
+    if (codex) return codex;
+  }
+
+  return parseSnapshot(message.result.rateLimits);
+};
+
+export const formatWindowDurationMins = (minutes: number) => {
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+};
+
+export const formatResetAt = (
+  unixSeconds: number,
+  options?: FormatCodexUsageOptions,
+) => {
+  const parts = new Intl.DateTimeFormat(options?.locale ?? DEFAULT_LOCALE, {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: options?.timeZone,
+  }).formatToParts(new Date(unixSeconds * 1000));
+
+  const getPart = (type: string) =>
+    parts.find((part) => part.type === type)?.value ?? "00";
+
+  return `${getPart("month")}/${getPart("day")} ${getPart("hour")}:${
+    getPart("minute")
+  }`;
+};
+
+const formatPlan = (planType: string | undefined) => {
+  const normalized = planType?.trim();
+  if (!normalized) return "Codex";
+  return `Codex ${normalized[0]?.toUpperCase()}${normalized.slice(1)}`;
+};
+
+const formatWindow = (
+  window: RateLimitWindow | undefined,
+  options?: FormatCodexUsageOptions,
+) => {
+  if (!window) return undefined;
+
+  const duration = window.windowDurationMins === undefined
+    ? undefined
+    : formatWindowDurationMins(window.windowDurationMins);
+  const percent = `${Math.round(window.usedPercent)}%`;
+  const usage = duration ? `${duration} ${percent}` : percent;
+  const reset = window.resetsAt === undefined
+    ? ""
+    : ` ↻${formatResetAt(window.resetsAt, options)}`;
+  return `${usage}${reset}`;
+};
+
+export const formatCodexUsageStatus = (
+  snapshot: CodexRateLimitSnapshot,
+  options?: FormatCodexUsageOptions,
+) => {
+  const windows = [
+    formatWindow(snapshot.primary, options),
+    formatWindow(snapshot.secondary, options),
+  ].filter((window): window is string => window !== undefined);
+
+  const usage = windows.length > 0 ? ` ${windows.join(" · ")}` : "";
+  return `${formatPlan(snapshot.planType)}${usage}`;
+};
+
+export const createJsonLineParser = (
+  onMessage: (message: unknown) => void,
+) => {
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const parseLine = (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      onMessage(JSON.parse(trimmed));
+    } catch {
+      // Ignore non-protocol output instead of breaking usage display.
+    }
+  };
+
+  return {
+    push: (chunk: Uint8Array | string) => {
+      buffer += typeof chunk === "string"
+        ? chunk
+        : decoder.decode(chunk, { stream: true });
+
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        parseLine(buffer.slice(0, newline));
+        buffer = buffer.slice(newline + 1);
+        newline = buffer.indexOf("\n");
+      }
+    },
+    end: () => {
+      buffer += decoder.decode();
+      parseLine(buffer);
+      buffer = "";
+    },
+  };
+};
+
+const createCodexAppServer: CreateCodexAppServer = ({
+  codexBin,
+  timeoutMs,
+  signal,
+}) => {
+  const child = spawn(codexBin, ["app-server", "--listen", "stdio://"], {
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+  let nextId = 0;
+  let closing = false;
+  let closed = false;
+  const pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  const rejectPending = (error: Error) => {
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+  };
+
+  const stop = (error: Error) => {
+    rejectPending(error);
+    if (child.exitCode !== null || child.killed) return;
+    child.kill("SIGKILL");
+  };
+
+  const parser = createJsonLineParser((message) => {
+    if (!isRecord(message) || typeof message.id !== "number") return;
+    const request = pending.get(message.id);
+    if (!request) return;
+
+    pending.delete(message.id);
+    if (message.error !== undefined) {
+      request.reject(new Error("Codex app-server request failed"));
+      return;
+    }
+    request.resolve(message);
+  });
+
+  child.stdout.on("data", (chunk: Uint8Array) => parser.push(chunk));
+  child.stdout.on("end", () => parser.end());
+  child.stdin.on(
+    "error",
+    () => stop(new Error("Codex app-server stdin error")),
+  );
+  child.on("error", () => stop(new Error("Failed to start Codex app-server")));
+  child.on("close", () => {
+    closed = true;
+    if (!closing) stop(new Error("Codex app-server exited"));
+  });
+
+  const timeout = setTimeout(
+    () => stop(new Error("Codex app-server timed out")),
+    timeoutMs,
+  );
+  const onAbort = () => stop(new Error("Codex usage refresh aborted"));
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) onAbort();
+
+  const write = (message: unknown) => {
+    if (child.killed || child.exitCode !== null) {
+      throw new Error("Codex app-server is not running");
+    }
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  };
+
+  return {
+    request: (method, params) => {
+      const id = ++nextId;
+      const response = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+      });
+      const message = params === undefined
+        ? { id, method }
+        : { id, method, params };
+      try {
+        write(message);
+      } catch (error) {
+        pending.delete(id);
+        return Promise.reject(error);
+      }
+      return response;
+    },
+    notify: (method) => write({ method }),
+    close: async () => {
+      closing = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      rejectPending(new Error("Codex app-server closed"));
+
+      if (closed) return;
+      const didClose = new Promise<void>((resolve) =>
+        child.once("close", resolve)
+      );
+      if (!child.killed && child.exitCode === null) child.kill("SIGKILL");
+      await didClose;
+    },
+  };
+};
+
+export const queryCodexUsage = async (options?: QueryCodexUsageOptions) => {
+  const server = (options?.createAppServer ?? createCodexAppServer)({
+    codexBin: options?.codexBin ?? "codex",
+    timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    signal: options?.signal,
+  });
+
+  try {
+    await server.request("initialize", {
+      clientInfo: { name: "pi-codex-usage", version: "0.1.0" },
+      capabilities: { experimentalApi: true },
+    });
+    server.notify("initialized");
+
+    const response = await server.request("account/rateLimits/read");
+    const snapshot = parseRateLimitsReadResponse(response);
+    if (!snapshot) throw new Error("Codex rate limits response was malformed");
+    return snapshot;
+  } finally {
+    await server.close();
+  }
+};

--- a/pi/agent/tests/codex-usage.test.ts
+++ b/pi/agent/tests/codex-usage.test.ts
@@ -1,0 +1,238 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@1.0";
+import {
+  createJsonLineParser,
+  formatCodexUsageStatus,
+  parseRateLimitsReadResponse,
+  queryCodexUsage,
+} from "../lib/codex-usage.ts";
+
+const RESET_AT = Date.UTC(2025, 0, 25, 0, 0) / 1000;
+const SECONDARY_RESET_AT = Date.UTC(2025, 0, 26, 12, 0) / 1000;
+const UTC = { timeZone: "UTC" } as const;
+const sampleSnapshot = {
+  planType: "pro",
+  primary: {
+    usedPercent: 0,
+    windowDurationMins: 10_080,
+    resetsAt: RESET_AT,
+  },
+};
+
+Deno.test("parseRateLimitsReadResponse prefers the codex bucket", () => {
+  assertEquals(
+    parseRateLimitsReadResponse({
+      id: 2,
+      result: {
+        rateLimits: {
+          planType: "plus",
+          primary: { usedPercent: 99, windowDurationMins: 60 },
+        },
+        rateLimitsByLimitId: { codex: sampleSnapshot },
+      },
+    }),
+    sampleSnapshot,
+  );
+});
+
+Deno.test("parseRateLimitsReadResponse falls back to rateLimits", () => {
+  assertEquals(
+    parseRateLimitsReadResponse({
+      id: 2,
+      result: { rateLimits: sampleSnapshot },
+    }),
+    sampleSnapshot,
+  );
+});
+
+Deno.test(
+  "parseRateLimitsReadResponse falls back when codex bucket is missing",
+  () => {
+    assertEquals(
+      parseRateLimitsReadResponse({
+        id: 2,
+        result: {
+          rateLimits: sampleSnapshot,
+          rateLimitsByLimitId: { other: { planType: "plus" } },
+        },
+      }),
+      sampleSnapshot,
+    );
+  },
+);
+
+Deno.test("parseRateLimitsReadResponse rejects malformed payloads", () => {
+  assertEquals(parseRateLimitsReadResponse(undefined), undefined);
+  assertEquals(
+    parseRateLimitsReadResponse({ id: 2, error: { message: "nope" } }),
+    undefined,
+  );
+  assertEquals(
+    parseRateLimitsReadResponse({ id: 2, result: { rateLimits: "bad" } }),
+    undefined,
+  );
+});
+
+Deno.test("formatCodexUsageStatus formats one window and reset", () => {
+  assertEquals(
+    formatCodexUsageStatus(sampleSnapshot, UTC),
+    "Codex Pro 7d 0% ↻01/25 00:00",
+  );
+});
+
+Deno.test("formatCodexUsageStatus formats two windows compactly", () => {
+  assertEquals(
+    formatCodexUsageStatus(
+      {
+        ...sampleSnapshot,
+        secondary: { usedPercent: 15, windowDurationMins: 300 },
+      },
+      UTC,
+    ),
+    "Codex Pro 7d 0% ↻01/25 00:00 · 5h 15%",
+  );
+});
+
+Deno.test("formatCodexUsageStatus shows each window reset time", () => {
+  assertEquals(
+    formatCodexUsageStatus(
+      {
+        ...sampleSnapshot,
+        secondary: {
+          usedPercent: 15,
+          windowDurationMins: 300,
+          resetsAt: SECONDARY_RESET_AT,
+        },
+      },
+      UTC,
+    ),
+    "Codex Pro 7d 0% ↻01/25 00:00 · 5h 15% ↻01/26 12:00",
+  );
+});
+
+Deno.test("formatCodexUsageStatus handles missing duration and reset", () => {
+  assertEquals(
+    formatCodexUsageStatus({
+      planType: "pro",
+      primary: { usedPercent: 42 },
+    }),
+    "Codex Pro 42%",
+  );
+});
+
+Deno.test("createJsonLineParser handles split chunks and malformed lines", () => {
+  const messages: unknown[] = [];
+  const parser = createJsonLineParser((message) => messages.push(message));
+
+  parser.push('{"id":');
+  parser.push('1}\nnot-json\n{"id":2}\n{"id"');
+  parser.push(":3}");
+  parser.end();
+
+  assertEquals(messages, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+});
+
+Deno.test("queryCodexUsage performs the app-server handshake", async () => {
+  const events: string[] = [];
+
+  const snapshot = await queryCodexUsage({
+    createAppServer: () => ({
+      request: (method, params) => {
+        events.push(`request:${method}`);
+        if (method === "initialize") {
+          assertEquals(params, {
+            clientInfo: { name: "pi-codex-usage", version: "0.1.0" },
+            capabilities: { experimentalApi: true },
+          });
+          return Promise.resolve({ id: 1, result: {} });
+        }
+        return Promise.resolve({
+          id: 2,
+          result: { rateLimitsByLimitId: { codex: sampleSnapshot } },
+        });
+      },
+      notify: (method) => {
+        events.push(`notify:${method}`);
+      },
+      close: () => {
+        events.push("close");
+        return Promise.resolve();
+      },
+    }),
+  });
+
+  assertEquals(snapshot, sampleSnapshot);
+  assertEquals(events, [
+    "request:initialize",
+    "notify:initialized",
+    "request:account/rateLimits/read",
+    "close",
+  ]);
+});
+
+Deno.test("queryCodexUsage rejects when Codex CLI is unavailable", async () => {
+  await assertRejects(
+    () =>
+      queryCodexUsage({
+        codexBin: "__missing_codex_for_test__",
+        timeoutMs: 100,
+      }),
+    Error,
+  );
+});
+
+Deno.test("queryCodexUsage closes after initialize rejection", async () => {
+  const events: string[] = [];
+
+  await assertRejects(
+    () =>
+      queryCodexUsage({
+        createAppServer: () => ({
+          request: (method) => {
+            events.push(`request:${method}`);
+            if (method === "initialize") {
+              return Promise.reject(new Error("initialize failed"));
+            }
+            return Promise.resolve({ id: 2, result: {} });
+          },
+          notify: (method) => {
+            events.push(`notify:${method}`);
+          },
+          close: () => {
+            events.push("close");
+            return Promise.resolve();
+          },
+        }),
+      }),
+    Error,
+    "initialize failed",
+  );
+
+  assertEquals(events, ["request:initialize", "close"]);
+});
+
+Deno.test("queryCodexUsage closes after malformed responses", async () => {
+  let closed = false;
+
+  await assertRejects(
+    () =>
+      queryCodexUsage({
+        createAppServer: () => ({
+          request: (method) => {
+            if (method === "initialize") {
+              return Promise.resolve({ id: 1, result: {} });
+            }
+            return Promise.resolve({ id: 2, result: "bad" });
+          },
+          notify: () => {},
+          close: () => {
+            closed = true;
+            return Promise.resolve();
+          },
+        }),
+      }),
+    Error,
+    "Codex rate limits response was malformed",
+  );
+
+  assertEquals(closed, true);
+});


### PR DESCRIPTION
## 概要
- Piの標準footerにChatGPT Codexプランの利用率とリセット時刻を表示します
- ローカルで認証済みの`codex app-server`から取得するため、API課金情報とは分離されます
- セッション開始・モデル切替・ターン完了時に自動更新し、`/codex-usage`でも手動更新できます

## 変更内容
- `account/rateLimits/read`のJSONL handshake、timeout、abort、プロセス終了処理を追加
- primary/secondaryの利用枠と個別リセット時刻をコンパクトに整形
- UIを持たない実行モードではapp-serverを起動しないよう制御
- 応答解析、chunk分割、handshake順序、異常終了をテスト

## 確認
- [x] `deno fmt --check pi/agent/lib/codex-usage.ts pi/agent/extensions/codex-usage.ts pi/agent/tests/codex-usage.test.ts`
- [x] `deno lint pi/agent/lib/codex-usage.ts pi/agent/extensions/codex-usage.ts pi/agent/tests/codex-usage.test.ts`
- [x] `deno test pi/agent/tests/*.test.ts`（50 passed）
- [x] 実際のCodex CLIからusageを取得して表示を確認