### PR TITLE
Piの普段使いをGPT-5.6 Sol xhighへ切り替える

### DIFF
--- a/pi/agent/model-roles.json
+++ b/pi/agent/model-roles.json
@@ -8,7 +8,7 @@
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
     "anthropic/claude-opus-5:max",
-    "openai-codex/gpt-5.6-sol:high",
+    "openai-codex/gpt-5.6-sol:xhigh",
     "openai-codex/gpt-5.6-sol:max",
     "openai-codex/gpt-5.6-terra:high",
     "openai-codex/gpt-5.6-terra:max",
@@ -50,7 +50,7 @@
     ],
     "2": [
       { "pi": "cursor/cursor-grok-4.6-fast", "base": 60, "perKb": 3 },
-      { "pi": "openai-codex/gpt-5.6-sol:high", "base": 90, "perKb": 3 },
+      { "pi": "openai-codex/gpt-5.6-sol:xhigh", "base": 90, "perKb": 3 },
       { "pi": "anthropic/claude-opus-5:high", "base": 60, "perKb": 3 },
       { "pi": "sakana-ai-console/fugu-ultra:high", "base": 180, "perKb": 8 }
     ],

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -37,7 +37,7 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.84.1",
+  "lastChangelogVersion": "0.84.2",
   "packages": [
     "git:github.com/kouvaliasnick/pi-cursor@fix/goaway-after-turn-ended"
   ]

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,7 +1,7 @@
 {
-  "defaultProvider": "sakana-ai-console",
-  "defaultModel": "fugu",
-  "defaultThinkingLevel": "high",
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-sol",
+  "defaultThinkingLevel": "xhigh",
   "enabledModels": [
     "cursor/composer-2.5-fast",
     "cursor/cursor-grok-4.6-fast",
@@ -10,7 +10,7 @@
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
     "anthropic/claude-opus-5:max",
-    "openai-codex/gpt-5.6-sol:high",
+    "openai-codex/gpt-5.6-sol:xhigh",
     "openai-codex/gpt-5.6-sol:max",
     "openai-codex/gpt-5.6-terra:high",
     "openai-codex/gpt-5.6-terra:max",


### PR DESCRIPTION
## 概要
- Piの普段使いをFuguからGPT-5.6 Solへ切り替えます
- GPT-5.6 Solのreasoning選択肢を`xhigh`と`max`に揃え、既定を`xhigh`にします

## 変更内容
- `pi/agent/settings.json`の既定provider/model/thinking levelを`openai-codex` / `gpt-5.6-sol` / `xhigh`へ変更
- モデルカタログとparallel-review Level 2のGPT-5.6 Solを`high`から`xhigh`へ変更
- Level 3の`max`は維持
- `lastChangelogVersion`を`0.84.2`へ更新

## 確認
- [x] `./pi/agent/resolve-model.sh --check`
- [x] `bats pi/agent/tests/resolve-model.bats`（6件成功）
- [x] JSON構文と`gpt-5.6-sol:high`の残存なしを確認