### PR TITLE
Pi セッションを cmux workspace 名で再開しやすくする

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -209,6 +209,7 @@ Configured by `settings.json` via `extensions/*.ts` and npm packages.
 | `clamp-openai-output-tokens.ts` | Clamp normal OpenAI payloads to the minimum `max_output_tokens = 16`. |
 | `codex-usage.ts`                | Show ChatGPT Codex plan usage and reset time in Pi's footer. Refresh with `/codex-usage`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
+| `cmux-session-name.ts`          | Sync unnamed Pi session names from the caller cmux workspace `custom_title` for `/resume` search. |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
 | `repo-memory-local.ts`          | Local-only repo memory: `recall_memory` / `remember` / `review_memory` tools + `/repo-memory-review` command. |
 
@@ -239,6 +240,33 @@ model at turn settlement; manual `/model` selection cancels auto-restore. Use
 `/auto-fugu on|off|status` to toggle automatic routing; an
 empty `/auto-fugu` toggles ON/OFF. After editing extensions or routing logic,
 run `/reload` (core `node_modules` changes still require a Pi restart).
+
+### cmux session names
+
+`cmux-session-name.ts` gives unnamed Pi sessions a display name from the caller
+cmux workspace's **custom title** (`custom_title` only — not the generated
+`title` such as `π - dotsfile`). This makes `/resume` searchable for sessions
+started via `/skill:jj-workspace` or other cmux task workflows.
+
+The sync runs on `session_start` (workspace already renamed before Pi starts)
+and once on the first `agent_settled` (common case where the agent renames the
+workspace during the first task). Each extension instance performs at most two
+cmux lookups total (startup plus first settled). Later `agent_settled` events do
+not query cmux again. Lookups are serialized so subprocesses never overlap.
+
+It scopes to `CMUX_WORKSPACE_ID`, queries `cmux workspace list --json`
+non-interactively via `pi.exec` (preferring `CMUX_BUNDLED_CLI_PATH`), and calls
+`pi.setSessionName()` with the normalized custom title.
+
+An automatic name assigned at startup can update once after the first task when
+the workspace `custom_title` changes. Existing manual Pi session names are
+preserved: a non-empty name that differs from the extension's last auto-assigned
+name is treated as manual (including resumed/stored session names). The
+extension re-checks after the async cmux lookup so a concurrent manual name is
+never overwritten. Custom titles are normalized before use: C0/C1 control
+characters are replaced with spaces, whitespace runs collapse to a single space,
+and the result is capped at 120 Unicode code points. Failures (missing cmux,
+timeout, malformed JSON, missing workspace/custom title) fail silently.
 
 ### Repo memory
 

--- a/pi/agent/extensions/cmux-session-name.ts
+++ b/pi/agent/extensions/cmux-session-name.ts
@@ -1,0 +1,98 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  type ExecFn,
+  fetchCmuxWorkspaceCustomTitle,
+} from "../lib/cmux-session-name.ts";
+
+export type SyncCmuxSessionNameDeps = {
+  getSessionName: () => string | undefined;
+  setSessionName: (name: string) => void;
+  exec: ExecFn;
+  env?: Record<string, string | undefined>;
+  autoName?: string;
+};
+
+export const syncCmuxSessionName = async (
+  deps: SyncCmuxSessionNameDeps,
+): Promise<string | undefined> => {
+  const autoName = deps.autoName;
+  const currentName = deps.getSessionName()?.trim();
+
+  if (currentName && currentName !== autoName) {
+    return autoName;
+  }
+
+  const env = deps.env ?? process.env;
+  const workspaceId = env.CMUX_WORKSPACE_ID?.trim();
+  if (!workspaceId) return autoName;
+
+  const name = await fetchCmuxWorkspaceCustomTitle({
+    workspaceId,
+    exec: deps.exec,
+    env,
+  });
+  if (!name) return autoName;
+
+  const afterLookup = deps.getSessionName()?.trim();
+  if (afterLookup && afterLookup !== autoName) {
+    return autoName;
+  }
+
+  if (afterLookup !== name) {
+    deps.setSessionName(name);
+  }
+
+  return name;
+};
+
+const extensionDrains = new WeakMap<object, () => Promise<void>>();
+
+/** Test-only: await queued sync operations for a registered extension instance. */
+export const drainCmuxSessionNameSyncsForTest = (
+  pi: object,
+): Promise<void> => extensionDrains.get(pi)?.() ?? Promise.resolve();
+
+export default function cmuxSessionName(pi: ExtensionAPI) {
+  let autoName: string | undefined;
+  let startupScheduled = false;
+  let settledUsed = false;
+  let pendingSyncs: Promise<void> = Promise.resolve();
+  let queue: Promise<void> = Promise.resolve();
+
+  extensionDrains.set(pi, () => pendingSyncs);
+
+  const shouldSkipLookup = (): boolean => {
+    const current = pi.getSessionName()?.trim();
+    return Boolean(current && current !== autoName);
+  };
+
+  const enqueueSync = (): void => {
+    queue = queue.then(async () => {
+      try {
+        autoName = await syncCmuxSessionName({
+          getSessionName: () => pi.getSessionName(),
+          setSessionName: (name) => pi.setSessionName(name),
+          exec: (command, args, options) => pi.exec(command, args, options),
+          autoName,
+        });
+      } catch {
+        // convenience integration: swallow errors
+      }
+    });
+    pendingSyncs = queue;
+  };
+
+  pi.on("session_start", () => {
+    if (startupScheduled) return;
+    startupScheduled = true;
+    if (shouldSkipLookup()) return;
+    enqueueSync();
+  });
+
+  pi.on("agent_settled", () => {
+    if (settledUsed) return;
+    settledUsed = true;
+    if (shouldSkipLookup()) return;
+    enqueueSync();
+  });
+}

--- a/pi/agent/lib/cmux-session-name.ts
+++ b/pi/agent/lib/cmux-session-name.ts
@@ -1,0 +1,103 @@
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+  code: number;
+  killed: boolean;
+};
+
+export type ExecFn = (
+  command: string,
+  args: string[],
+  options?: { signal?: AbortSignal; timeout?: number; cwd?: string },
+) => Promise<ExecResult>;
+
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isControlChar = (char: string): boolean => {
+  const code = char.codePointAt(0)!;
+  return (code >= 0x00 && code <= 0x1f) || (code >= 0x7f && code <= 0x9f);
+};
+
+export const normalizeCustomTitle = (title: string): string | undefined => {
+  const replaced = Array.from(title)
+    .map((char) => (isControlChar(char) ? " " : char))
+    .join("");
+  const collapsed = replaced.replace(/\s+/g, " ").trim();
+  if (!collapsed) return undefined;
+  const limited = Array.from(collapsed).slice(0, 120).join("");
+  return limited || undefined;
+};
+
+export const resolveCmuxCliPath = (
+  env: Record<string, string | undefined> = process.env,
+): string => {
+  const bundled = env.CMUX_BUNDLED_CLI_PATH?.trim();
+  return bundled || "cmux";
+};
+
+export const parseWorkspaceCustomTitle = (
+  json: string,
+  workspaceId: string,
+): string | undefined => {
+  const targetId = workspaceId.trim();
+  if (!targetId) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+
+  if (!isRecord(parsed)) return undefined;
+  const workspaces = parsed.workspaces;
+  if (!Array.isArray(workspaces)) return undefined;
+
+  for (const entry of workspaces) {
+    if (!isRecord(entry)) continue;
+    if (entry.id !== targetId) continue;
+
+    const customTitle = entry.custom_title;
+    if (typeof customTitle !== "string") return undefined;
+
+    return normalizeCustomTitle(customTitle);
+  }
+
+  return undefined;
+};
+
+export type FetchCmuxWorkspaceCustomTitleOptions = {
+  workspaceId: string;
+  exec: ExecFn;
+  cmuxBin?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export const fetchCmuxWorkspaceCustomTitle = async (
+  options: FetchCmuxWorkspaceCustomTitleOptions,
+): Promise<string | undefined> => {
+  const workspaceId = options.workspaceId.trim();
+  if (!workspaceId) return undefined;
+
+  const cmuxBin = options.cmuxBin ?? resolveCmuxCliPath(options.env);
+
+  try {
+    const result = await options.exec(
+      cmuxBin,
+      ["workspace", "list", "--json"],
+      {
+        timeout: options.timeoutMs ?? 5000,
+        signal: options.signal,
+      },
+    );
+    if (result.killed || result.code !== 0) return undefined;
+    return parseWorkspaceCustomTitle(result.stdout, workspaceId);
+  } catch {
+    return undefined;
+  }
+};

--- a/pi/agent/tests/cmux-session-name.test.ts
+++ b/pi/agent/tests/cmux-session-name.test.ts
@@ -1,0 +1,661 @@
+import { assertEquals } from "jsr:@std/assert@1.0";
+import cmuxSessionName, {
+  drainCmuxSessionNameSyncsForTest,
+  syncCmuxSessionName,
+} from "../extensions/cmux-session-name.ts";
+import {
+  fetchCmuxWorkspaceCustomTitle,
+  normalizeCustomTitle,
+  parseWorkspaceCustomTitle,
+  resolveCmuxCliPath,
+} from "../lib/cmux-session-name.ts";
+
+const CALLER_ID = "ws-caller";
+const OTHER_ID = "ws-other";
+
+const sampleListJson = JSON.stringify({
+  workspaces: [
+    {
+      id: OTHER_ID,
+      custom_title: "other task",
+      has_custom_title: true,
+      title: "other task",
+    },
+    {
+      id: CALLER_ID,
+      custom_title: "  jj workspace fix  ",
+      has_custom_title: true,
+      title: "jj workspace fix",
+    },
+  ],
+});
+
+function listJsonForTitle(title: string): string {
+  return JSON.stringify({
+    workspaces: [{ id: CALLER_ID, custom_title: title }],
+  });
+}
+
+Deno.test("parseWorkspaceCustomTitle selects caller workspace by exact id", () => {
+  assertEquals(
+    parseWorkspaceCustomTitle(sampleListJson, CALLER_ID),
+    "jj workspace fix",
+  );
+});
+
+Deno.test("parseWorkspaceCustomTitle returns trimmed custom_title", () => {
+  assertEquals(
+    parseWorkspaceCustomTitle(
+      JSON.stringify({
+        workspaces: [{
+          id: CALLER_ID,
+          custom_title: "  task name  ",
+          title: "ignored",
+        }],
+      }),
+      CALLER_ID,
+    ),
+    "task name",
+  );
+});
+
+Deno.test("parseWorkspaceCustomTitle rejects generated title without custom_title", () => {
+  assertEquals(
+    parseWorkspaceCustomTitle(
+      JSON.stringify({
+        workspaces: [{
+          id: CALLER_ID,
+          title: "π - dotsfile",
+          has_custom_title: false,
+        }],
+      }),
+      CALLER_ID,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("parseWorkspaceCustomTitle rejects malformed or missing data", () => {
+  assertEquals(parseWorkspaceCustomTitle("{bad json", CALLER_ID), undefined);
+  assertEquals(parseWorkspaceCustomTitle("[]", CALLER_ID), undefined);
+  assertEquals(
+    parseWorkspaceCustomTitle(sampleListJson, "missing-id"),
+    undefined,
+  );
+  assertEquals(
+    parseWorkspaceCustomTitle(
+      JSON.stringify({
+        workspaces: [{ id: CALLER_ID, custom_title: "   " }],
+      }),
+      CALLER_ID,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("normalizeCustomTitle replaces control characters and collapses whitespace", () => {
+  assertEquals(
+    normalizeCustomTitle("fix\tbug\nnow"),
+    "fix bug now",
+  );
+  assertEquals(
+    normalizeCustomTitle("  hello   world  "),
+    "hello world",
+  );
+  assertEquals(
+    normalizeCustomTitle("\u0000\u001f\u007f\u009f"),
+    undefined,
+  );
+});
+
+Deno.test("normalizeCustomTitle limits to 120 Unicode code points", () => {
+  const longTitle = "あ".repeat(150);
+  const normalized = normalizeCustomTitle(longTitle);
+  assertEquals(normalized, "あ".repeat(120));
+  assertEquals(Array.from(normalized ?? "").length, 120);
+});
+
+Deno.test("parseWorkspaceCustomTitle normalizes control characters and length", () => {
+  assertEquals(
+    parseWorkspaceCustomTitle(
+      listJsonForTitle("task\u0001name\nwith\tspaces"),
+      CALLER_ID,
+    ),
+    "task name with spaces",
+  );
+
+  const longTitle = "x".repeat(200);
+  assertEquals(
+    parseWorkspaceCustomTitle(listJsonForTitle(longTitle), CALLER_ID),
+    "x".repeat(120),
+  );
+});
+
+Deno.test("resolveCmuxCliPath prefers CMUX_BUNDLED_CLI_PATH", () => {
+  assertEquals(
+    resolveCmuxCliPath({ CMUX_BUNDLED_CLI_PATH: "/tmp/cmux" }),
+    "/tmp/cmux",
+  );
+  assertEquals(resolveCmuxCliPath({}), "cmux");
+});
+
+type Handler = (_event: unknown, _ctx: unknown) => unknown;
+
+function createFakePi(options?: {
+  exec?: (
+    command: string,
+    args: string[],
+  ) => Promise<
+    { stdout: string; stderr: string; code: number; killed: boolean }
+  >;
+}) {
+  const handlers = new Map<string, Handler[]>();
+  let sessionName: string | undefined;
+  const execCalls: Array<{ command: string; args: string[] }> = [];
+
+  const exec = options?.exec ?? (() =>
+    Promise.resolve({
+      stdout: sampleListJson,
+      stderr: "",
+      code: 0,
+      killed: false,
+    }));
+
+  const pi = {
+    on(type: string, handler: Handler) {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    },
+    getSessionName() {
+      return sessionName;
+    },
+    setSessionName(name: string) {
+      sessionName = name;
+    },
+    exec(command: string, args: string[], _options?: unknown) {
+      execCalls.push({ command, args });
+      return exec(command, args);
+    },
+  };
+
+  const dispatch = async (type: string) => {
+    for (const handler of handlers.get(type) ?? []) {
+      await handler({}, {});
+    }
+  };
+
+  return {
+    pi,
+    dispatch,
+    execCalls,
+    getSessionName: () => sessionName,
+    setSessionName: (name: string | undefined) => {
+      sessionName = name;
+    },
+  };
+}
+
+function withCmuxEnv<T>(
+  env: {
+    workspaceId?: string;
+    bundledCliPath?: string | null;
+  },
+  fn: () => Promise<T> | T,
+): Promise<T> | T {
+  const keys = ["CMUX_WORKSPACE_ID", "CMUX_BUNDLED_CLI_PATH"] as const;
+  const previous = Object.fromEntries(
+    keys.map((key) => [key, Deno.env.get(key)]),
+  ) as Record<(typeof keys)[number], string | undefined>;
+
+  const restore = () => {
+    for (const key of keys) {
+      const value = previous[key];
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  };
+
+  if (env.workspaceId === undefined) Deno.env.delete("CMUX_WORKSPACE_ID");
+  else Deno.env.set("CMUX_WORKSPACE_ID", env.workspaceId);
+
+  if (env.bundledCliPath === null) Deno.env.delete("CMUX_BUNDLED_CLI_PATH");
+  else if (env.bundledCliPath !== undefined) {
+    Deno.env.set("CMUX_BUNDLED_CLI_PATH", env.bundledCliPath);
+  }
+
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+function withCmuxWorkspaceId<T>(
+  workspaceId: string | undefined,
+  fn: () => Promise<T> | T,
+): Promise<T> | T {
+  return withCmuxEnv({ workspaceId, bundledCliPath: null }, fn);
+}
+
+Deno.test("extension sets unnamed session on session_start", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    const fake = createFakePi();
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), "jj workspace fix");
+    assertEquals(fake.execCalls, [{
+      command: "cmux",
+      args: ["workspace", "list", "--json"],
+    }]);
+  });
+});
+
+Deno.test("extension updates auto name on first agent_settled only", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    let callCount = 0;
+    const fake = createFakePi({
+      exec: () => {
+        callCount += 1;
+        const title = callCount === 1 ? "old-task" : "new-task";
+        return Promise.resolve({
+          stdout: listJsonForTitle(title),
+          stderr: "",
+          code: 0,
+          killed: false,
+        });
+      },
+    });
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "old-task");
+    assertEquals(fake.execCalls.length, 1);
+
+    await fake.dispatch("agent_settled");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "new-task");
+    assertEquals(fake.execCalls.length, 2);
+
+    await fake.dispatch("agent_settled");
+    await fake.dispatch("agent_settled");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "new-task");
+    assertEquals(fake.execCalls.length, 2);
+  });
+});
+
+Deno.test("extension preserves manual name set before first agent_settled", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    const fake = createFakePi();
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "jj workspace fix");
+    assertEquals(fake.execCalls.length, 1);
+
+    fake.setSessionName("manual name");
+
+    await fake.dispatch("agent_settled");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "manual name");
+    assertEquals(fake.execCalls.length, 1);
+  });
+});
+
+Deno.test("extension preserves manual name set during first-settled lookup", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    let resolveStartup: (value: {
+      stdout: string;
+      stderr: string;
+      code: number;
+      killed: boolean;
+    }) => void = () => {};
+    let resolveSettled: (value: {
+      stdout: string;
+      stderr: string;
+      code: number;
+      killed: boolean;
+    }) => void = () => {};
+
+    let callCount = 0;
+    const fake = createFakePi({
+      exec: () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return new Promise((resolve) => {
+            resolveStartup = resolve;
+          });
+        }
+        return new Promise((resolve) => {
+          resolveSettled = resolve;
+        });
+      },
+    });
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    resolveStartup({
+      stdout: listJsonForTitle("old-task"),
+      stderr: "",
+      code: 0,
+      killed: false,
+    });
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "old-task");
+
+    const settledDispatch = fake.dispatch("agent_settled");
+    await Promise.resolve();
+    assertEquals(fake.execCalls.length, 2);
+    assertEquals(fake.getSessionName(), "old-task");
+
+    fake.setSessionName("manual during settled lookup");
+    resolveSettled({
+      stdout: listJsonForTitle("new-task"),
+      stderr: "",
+      code: 0,
+      killed: false,
+    });
+    await settledDispatch;
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), "manual during settled lookup");
+  });
+});
+
+Deno.test("extension performs at most two lookups across lifecycle", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    const fake = createFakePi({
+      exec: () =>
+        Promise.resolve({
+          stdout: JSON.stringify({ workspaces: [] }),
+          stderr: "",
+          code: 0,
+          killed: false,
+        }),
+    });
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await fake.dispatch("agent_settled");
+    await fake.dispatch("agent_settled");
+    await fake.dispatch("agent_settled");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.execCalls.length, 2);
+  });
+});
+
+Deno.test("extension serializes startup and first-settled lookups", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    let callCount = 0;
+
+    let releaseStartup!: () => void;
+    let releaseSettled!: () => void;
+    const startupGate = new Promise<void>((resolve) => {
+      releaseStartup = resolve;
+    });
+    const settledGate = new Promise<void>((resolve) => {
+      releaseSettled = resolve;
+    });
+
+    const fake = createFakePi({
+      exec: () => {
+        callCount += 1;
+        concurrent += 1;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        const current = callCount;
+        return (current === 1 ? startupGate : settledGate).then(() => {
+          concurrent -= 1;
+          const title = current === 1 ? "startup-task" : "settled-task";
+          return {
+            stdout: listJsonForTitle(title),
+            stderr: "",
+            code: 0,
+            killed: false,
+          };
+        });
+      },
+    });
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await fake.dispatch("agent_settled");
+    assertEquals(maxConcurrent, 1);
+    assertEquals(fake.execCalls.length, 1);
+
+    releaseStartup();
+    releaseSettled();
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+    assertEquals(fake.getSessionName(), "settled-task");
+    assertEquals(fake.execCalls.length, 2);
+    assertEquals(maxConcurrent, 1);
+  });
+});
+
+Deno.test("extension preserves existing manual Pi session name", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    const fake = createFakePi();
+    fake.setSessionName("manual name");
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), "manual name");
+    assertEquals(fake.execCalls.length, 0);
+  });
+});
+
+Deno.test("extension re-checks session name after async lookup", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    let resolveExec: (value: {
+      stdout: string;
+      stderr: string;
+      code: number;
+      killed: boolean;
+    }) => void = () => {};
+    const execPromise = new Promise<{
+      stdout: string;
+      stderr: string;
+      code: number;
+      killed: boolean;
+    }>((resolve) => {
+      resolveExec = resolve;
+    });
+
+    const fake = createFakePi({
+      exec: () => execPromise,
+    });
+    cmuxSessionName(fake.pi as never);
+
+    const pending = fake.dispatch("session_start");
+    assertEquals(fake.getSessionName(), undefined);
+
+    fake.setSessionName("manual during lookup");
+    resolveExec({
+      stdout: sampleListJson,
+      stderr: "",
+      code: 0,
+      killed: false,
+    });
+    await pending;
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), "manual during lookup");
+  });
+});
+
+Deno.test("no CMUX_WORKSPACE_ID means no lookup or rename", async () => {
+  await withCmuxWorkspaceId(undefined, async () => {
+    const fake = createFakePi();
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), undefined);
+    assertEquals(fake.execCalls.length, 0);
+  });
+});
+
+Deno.test("cmux execution failure is silent and does not rename", async () => {
+  await withCmuxWorkspaceId(CALLER_ID, async () => {
+    const fake = createFakePi({
+      exec: () =>
+        Promise.resolve({
+          stdout: "",
+          stderr: "boom",
+          code: 1,
+          killed: false,
+        }),
+    });
+    cmuxSessionName(fake.pi as never);
+
+    await fake.dispatch("session_start");
+    await drainCmuxSessionNameSyncsForTest(fake.pi);
+
+    assertEquals(fake.getSessionName(), undefined);
+  });
+});
+
+Deno.test("fetchCmuxWorkspaceCustomTitle uses bundled cmux path", async () => {
+  const execCalls: Array<{ command: string; args: string[] }> = [];
+  const name = await fetchCmuxWorkspaceCustomTitle({
+    workspaceId: CALLER_ID,
+    env: { CMUX_BUNDLED_CLI_PATH: "/Applications/cmux.app/cmux" },
+    exec: (command, args) => {
+      execCalls.push({ command, args });
+      return Promise.resolve({
+        stdout: sampleListJson,
+        stderr: "",
+        code: 0,
+        killed: false,
+      });
+    },
+  });
+
+  assertEquals(name, "jj workspace fix");
+  assertEquals(execCalls, [{
+    command: "/Applications/cmux.app/cmux",
+    args: ["workspace", "list", "--json"],
+  }]);
+});
+
+Deno.test("syncCmuxSessionName skips lookup when session already named manually", async () => {
+  let execCalled = false;
+  await syncCmuxSessionName({
+    getSessionName: () => "existing",
+    setSessionName: () => {},
+    exec: () => {
+      execCalled = true;
+      return Promise.resolve({
+        stdout: "",
+        stderr: "",
+        code: 0,
+        killed: false,
+      });
+    },
+    env: { CMUX_WORKSPACE_ID: CALLER_ID },
+  });
+
+  assertEquals(execCalled, false);
+});
+
+Deno.test("syncCmuxSessionName updates when current name equals autoName", async () => {
+  let setCalls = 0;
+  const result = await syncCmuxSessionName({
+    getSessionName: () => "old-task",
+    setSessionName: (name) => {
+      setCalls += 1;
+      assertEquals(name, "new-task");
+    },
+    exec: () =>
+      Promise.resolve({
+        stdout: listJsonForTitle("new-task"),
+        stderr: "",
+        code: 0,
+        killed: false,
+      }),
+    env: { CMUX_WORKSPACE_ID: CALLER_ID },
+    autoName: "old-task",
+  });
+
+  assertEquals(result, "new-task");
+  assertEquals(setCalls, 1);
+});
+
+Deno.test("syncCmuxSessionName avoids duplicate setSessionName for unchanged name", async () => {
+  let setCalls = 0;
+  const result = await syncCmuxSessionName({
+    getSessionName: () => "same-task",
+    setSessionName: () => {
+      setCalls += 1;
+    },
+    exec: () =>
+      Promise.resolve({
+        stdout: listJsonForTitle("same-task"),
+        stderr: "",
+        code: 0,
+        killed: false,
+      }),
+    env: { CMUX_WORKSPACE_ID: CALLER_ID },
+    autoName: "same-task",
+  });
+
+  assertEquals(result, "same-task");
+  assertEquals(setCalls, 0);
+});
+
+Deno.test("syncCmuxSessionName preserves manual name after async lookup", async () => {
+  let resolveExec: (value: {
+    stdout: string;
+    stderr: string;
+    code: number;
+    killed: boolean;
+  }) => void = () => {};
+  const execPromise = new Promise<{
+    stdout: string;
+    stderr: string;
+    code: number;
+    killed: boolean;
+  }>((resolve) => {
+    resolveExec = resolve;
+  });
+
+  let sessionName = "old-task";
+  const pending = syncCmuxSessionName({
+    getSessionName: () => sessionName,
+    setSessionName: (name) => {
+      sessionName = name;
+    },
+    exec: () => execPromise,
+    env: { CMUX_WORKSPACE_ID: CALLER_ID },
+    autoName: "old-task",
+  });
+
+  sessionName = "manual override";
+  resolveExec({
+    stdout: listJsonForTitle("new-task"),
+    stderr: "",
+    code: 0,
+    killed: false,
+  });
+
+  const result = await pending;
+  assertEquals(result, "old-task");
+  assertEquals(sessionName, "manual override");
+});


### PR DESCRIPTION
## 概要
- `/skill:jj-workspace` などから起動した Pi セッションを `/resume` で識別しやすくします。
- caller cmux workspace の `custom_title` を Pi の session display name に同期します。
- 手動設定した session name は保持し、cmux 連携失敗は silent に扱います。

## 変更内容
- `session_start` と最初の `agent_settled` で最大2回だけ同期し、lookup を直列化
- `CMUX_WORKSPACE_ID` に一致する workspace の `custom_title` だけを使用
- 制御文字・空白・長さを正規化し、動作契約と回帰テストを追加

## 確認
- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno check`
- [x] `deno test -A pi/agent/tests/cmux-session-name.test.ts`（23 passed）
- [x] `deno test -A pi/agent/tests`（75 passed）