### PR TITLE
jj workspace作成後にPiの作業ディレクトリを自動切替する

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -210,6 +210,7 @@ Configured by `settings.json` via `extensions/*.ts` and npm packages.
 | `codex-usage.ts`                | Show ChatGPT Codex plan usage and reset time in Pi's footer. Refresh with `/codex-usage`. |
 | `auto-fugu-model.ts`            | Route everyday work on `fugu`; auto-escalate to `fugu-ultra` at high-stakes points or in-run struggle. Toggle with `/auto-fugu on\|off\|status`. |
 | `cmux-session-name.ts`          | Sync unnamed Pi session names from the caller cmux workspace `custom_title` for `/resume` search. |
+| `workspace-cd.ts`               | Fork/switch Pi session cwd after jj workspace setup (`switch_workspace_cwd` tool, `/workspace-cd`). |
 | `save-compaction-log.ts`        | Save compaction summaries to `~/.pi/agent/compaction-logs/`.         |
 | `repo-memory-local.ts`          | Local-only repo memory: `recall_memory` / `remember` / `review_memory` tools + `/repo-memory-review` command. |
 
@@ -267,6 +268,33 @@ never overwritten. Custom titles are normalized before use: C0/C1 control
 characters are replaced with spaces, whitespace runs collapse to a single space,
 and the result is capped at 120 Unicode code points. Failures (missing cmux,
 timeout, malformed JSON, missing workspace/custom title) fail silently.
+
+### workspace cwd switch
+
+`workspace-cd.ts` moves a **persisted** Pi session into another directory without
+losing conversation history. A child shell cannot change Pi's cwd, so the
+extension forks the current session with `SessionManager.forkFrom()` and switches
+to the fork via `ctx.switchSession()`.
+
+- **`switch_workspace_cwd` tool** — LLM-callable; used by `jj-workspace` as the
+  **final tool** after workspace creation, setup, and cmux `custom_title`/description
+  sync. Validates the destination path (`realpath`, must exist and be a directory),
+  requires a persisted source session (`getSessionFile()`), stores the canonical target
+  in extension-local state, returns `terminate: true`, and does **not** queue a follow-up
+  message. After the current run `agent_settled` and Pi is idle, dispatches internal
+  `/workspace-cd-continue <encoded-path>` with `expandPromptTemplates: true`. That
+  command switches sessions in a fresh context and sends one short continuation message
+  so the original task resumes in the new cwd automatically. Do not call any tools after
+  it in the old session.
+- **`/workspace-cd <path>`** — manual fork/switch without auto-continuation.
+  Relative paths resolve from the current Pi cwd. Same cwd is a no-op.
+- **`/workspace-cd-continue <encoded-path>`** — internal entrypoint dispatched after
+  settlement by the tool; not for manual use. If `switchSession` is cancelled, the
+  just-created fork session file is removed best-effort before surfacing the error.
+
+Requires a persisted source session (`getSessionFile()`). In-memory sessions
+cannot cross cwd; the tool throws `WorkspacePathError` before scheduling termination.
+Command errors surface via Pi's extension error UI.
 
 ### Repo memory
 

--- a/pi/agent/extensions/workspace-cd.ts
+++ b/pi/agent/extensions/workspace-cd.ts
@@ -1,0 +1,264 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { lstatSync, realpathSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const WORKSPACE_CD_COMMAND = "workspace-cd";
+export const WORKSPACE_CD_CONTINUE_COMMAND = "workspace-cd-continue";
+
+const CONTINUE_MESSAGE =
+  "(workspace-cd) jj workspace のセットアップが完了しました。このディレクトリで元のタスクを続けてください。";
+
+export class WorkspacePathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspacePathError";
+  }
+}
+
+export const resolveWorkspacePath = (input: string, cwd: string): string => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new WorkspacePathError("Path is required");
+  }
+
+  const absolute = resolve(cwd, trimmed);
+  let canonical: string;
+  try {
+    canonical = realpathSync.native(absolute);
+  } catch {
+    throw new WorkspacePathError(`Directory not found: ${trimmed}`);
+  }
+
+  try {
+    if (!lstatSync(canonical).isDirectory()) {
+      throw new WorkspacePathError(`Not a directory: ${trimmed}`);
+    }
+  } catch (error) {
+    if (error instanceof WorkspacePathError) throw error;
+    throw new WorkspacePathError(`Directory not found: ${trimmed}`);
+  }
+
+  return canonical;
+};
+
+export type SwitchWorkspaceDeps = {
+  forkFrom: typeof SessionManager.forkFrom;
+  switchSession: ExtensionCommandContext["switchSession"];
+  getSessionFile: () => string | undefined;
+  getCwd: () => string;
+};
+
+export const switchWorkspaceSession = async (
+  deps: SwitchWorkspaceDeps,
+  targetPath: string,
+  options?: { autoContinue?: boolean },
+) => {
+  const currentPath = resolveWorkspacePath(".", deps.getCwd());
+  const resolvedTarget = resolveWorkspacePath(targetPath, deps.getCwd());
+  if (resolvedTarget === currentPath) {
+    return { switched: false as const, targetPath: resolvedTarget };
+  }
+
+  const sourceSession = deps.getSessionFile();
+  if (!sourceSession) {
+    throw new WorkspacePathError(
+      "Current session is not persisted; cannot fork across cwd",
+    );
+  }
+
+  const forked = deps.forkFrom(sourceSession, resolvedTarget);
+  const targetSessionFile = forked.getSessionFile();
+  if (!targetSessionFile) {
+    throw new WorkspacePathError("Failed to create forked session file");
+  }
+
+  const result = await deps.switchSession(targetSessionFile, {
+    withSession: async (freshCtx) => {
+      if (freshCtx.hasUI) {
+        freshCtx.ui.notify(`Switched to ${resolvedTarget}`, "info");
+      }
+      if (options?.autoContinue) {
+        await freshCtx.sendUserMessage(CONTINUE_MESSAGE);
+      }
+    },
+  });
+
+  if (result.cancelled) {
+    try {
+      unlinkSync(targetSessionFile);
+    } catch {
+      // best-effort cleanup of the fork file we just created
+    }
+    throw new WorkspacePathError("Session switch was cancelled");
+  }
+
+  return {
+    switched: true as const,
+    targetPath: resolvedTarget,
+    sessionFile: targetSessionFile,
+  };
+};
+
+const notifyError = (
+  ctx: ExtensionCommandContext,
+  message: string,
+) => {
+  if (ctx.hasUI) ctx.ui.notify(message, "error");
+};
+
+const makeSwitchDeps = (
+  ctx: ExtensionCommandContext,
+): SwitchWorkspaceDeps => ({
+  forkFrom: SessionManager.forkFrom,
+  switchSession: (sessionPath, options) =>
+    ctx.switchSession(sessionPath, options),
+  getSessionFile: () => ctx.sessionManager.getSessionFile(),
+  getCwd: () => ctx.cwd,
+});
+
+export default function workspaceCd(pi: ExtensionAPI) {
+  let pendingTarget: string | undefined;
+  let dispatchTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearDispatchTimer = () => {
+    if (dispatchTimer !== undefined) {
+      clearTimeout(dispatchTimer);
+      dispatchTimer = undefined;
+    }
+  };
+
+  const scheduleContinueDispatch = (ctx: ExtensionContext) => {
+    clearDispatchTimer();
+    dispatchTimer = setTimeout(() => {
+      dispatchTimer = undefined;
+      const target = pendingTarget;
+      if (!target) return;
+      try {
+        if (!ctx.isIdle()) return;
+        pendingTarget = undefined;
+        pi.sendUserMessage(
+          `/${WORKSPACE_CD_CONTINUE_COMMAND} ${encodeURIComponent(target)}`,
+          // Runtime 0.84 supports command dispatch; deno.lock types are still 0.83.
+          { expandPromptTemplates: true } as Parameters<
+            typeof pi.sendUserMessage
+          >[1],
+        );
+      } catch {
+        // reload / shutdown で ctx/pi が無効化されても落とさない
+      }
+    }, 0);
+  };
+
+  pi.on("agent_settled", (_event, ctx) => {
+    if (!pendingTarget) return;
+    scheduleContinueDispatch(ctx);
+  });
+
+  pi.on("session_shutdown", () => {
+    pendingTarget = undefined;
+    clearDispatchTimer();
+  });
+
+  const runSwitch = async (
+    ctx: ExtensionCommandContext,
+    rawPath: string,
+    autoContinue: boolean,
+  ) => {
+    const resolved = resolveWorkspacePath(rawPath, ctx.cwd);
+    const outcome = await switchWorkspaceSession(
+      makeSwitchDeps(ctx),
+      resolved,
+      { autoContinue },
+    );
+
+    if (!outcome.switched && ctx.hasUI) {
+      ctx.ui.notify(`Already in ${resolved}`, "info");
+    }
+  };
+
+  pi.registerCommand(WORKSPACE_CD_COMMAND, {
+    description:
+      "Fork the current session and switch Pi cwd to another directory",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      if (!trimmed) {
+        if (ctx.hasUI) {
+          ctx.ui.notify("Usage: /workspace-cd <path>", "warning");
+        }
+        return;
+      }
+
+      await runSwitch(ctx, trimmed, false);
+    },
+  });
+
+  pi.registerCommand(WORKSPACE_CD_CONTINUE_COMMAND, {
+    description: "Internal: fork session into destination cwd and continue",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      if (!trimmed) {
+        const message = "Destination path is required";
+        notifyError(ctx, message);
+        throw new WorkspacePathError(message);
+      }
+
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(trimmed);
+      } catch {
+        decoded = trimmed;
+      }
+
+      await runSwitch(ctx, decoded, true);
+    },
+  });
+
+  pi.registerTool({
+    name: "switch_workspace_cwd",
+    label: "Switch Workspace CWD",
+    description:
+      "After jj workspace setup completes, fork this session into the destination directory and continue the original task there. Must be the final tool call in the current session.",
+    parameters: Type.Object({
+      path: Type.String({
+        description: "Destination jj workspace directory path",
+      }),
+    }),
+    execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolved = resolveWorkspacePath(params.path, ctx.cwd);
+      const currentPath = resolveWorkspacePath(".", ctx.cwd);
+      if (resolved === currentPath) {
+        return Promise.resolve({
+          content: [{
+            type: "text",
+            text: `Already in ${resolved}; no switch needed.`,
+          }],
+          details: { switched: false, path: resolved },
+        });
+      }
+
+      if (!ctx.sessionManager.getSessionFile()) {
+        throw new WorkspacePathError(
+          "Current session is not persisted; cannot fork across cwd",
+        );
+      }
+
+      pendingTarget = resolved;
+
+      return Promise.resolve({
+        content: [{
+          type: "text",
+          text:
+            `Scheduled session switch to ${resolved}. Do not call any more tools in this session; work will continue automatically in the new cwd after settlement.`,
+        }],
+        details: { path: resolved, scheduled: true },
+        terminate: true,
+      });
+    },
+  });
+}

--- a/pi/agent/tests/workspace-cd.test.ts
+++ b/pi/agent/tests/workspace-cd.test.ts
@@ -1,0 +1,637 @@
+import { assertEquals, assertRejects, assertThrows } from "jsr:@std/assert@1.0";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import workspaceCd, {
+  resolveWorkspacePath,
+  switchWorkspaceSession,
+  WORKSPACE_CD_COMMAND,
+  WORKSPACE_CD_CONTINUE_COMMAND,
+  WorkspacePathError,
+} from "../extensions/workspace-cd.ts";
+
+const makeTempDir = () => mkdtempSync(join(tmpdir(), "pi-workspace-cd-"));
+
+const persistSessionHistory = (session: SessionManager) => {
+  const timestamp = Date.now();
+  session.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "seed user" }],
+    timestamp,
+  });
+  session.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "seed assistant" }],
+    timestamp,
+    api: "openai-responses",
+    provider: "openai",
+    model: "test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+  });
+  session.appendCustomEntry("test.history", { note: "history marker" });
+};
+
+type CommandHandler = (
+  args: string,
+  ctx: Record<string, unknown>,
+) => Promise<void>;
+type ToolExecute = (
+  toolCallId: string,
+  params: { path: string },
+  signal: AbortSignal | undefined,
+  onUpdate: unknown,
+  ctx: Record<string, unknown>,
+) => Promise<
+  {
+    content: Array<{ type: string; text?: string }>;
+    details: unknown;
+    terminate?: boolean;
+  }
+>;
+type EventHandler = (
+  event: unknown,
+  ctx: Record<string, unknown>,
+) => void;
+
+function createFakePi(cwd: string) {
+  const commands = new Map<string, CommandHandler>();
+  const tools = new Map<string, ToolExecute>();
+  const eventHandlers = new Map<string, EventHandler[]>();
+  const sendCalls: Array<{ content: string; options?: unknown }> = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  let idle = true;
+
+  const pi = {
+    registerCommand(name: string, options: { handler: CommandHandler }) {
+      commands.set(name, options.handler);
+    },
+    registerTool(tool: { name: string; execute: ToolExecute }) {
+      tools.set(tool.name, tool.execute);
+    },
+    sendUserMessage(content: string, options?: unknown) {
+      sendCalls.push({ content, options });
+    },
+    on(event: string, handler: EventHandler) {
+      const handlers = eventHandlers.get(event) ?? [];
+      handlers.push(handler);
+      eventHandlers.set(event, handlers);
+    },
+  };
+
+  workspaceCd(pi as never);
+
+  const emit = (
+    event: string,
+    eventData: unknown,
+    ctx: Record<string, unknown>,
+  ) => {
+    for (const handler of eventHandlers.get(event) ?? []) {
+      handler(eventData, ctx);
+    }
+  };
+
+  const makeCtx = (overrides?: Partial<Record<string, unknown>>) => ({
+    cwd,
+    hasUI: true,
+    isIdle: () => idle,
+    ui: {
+      notify: (message: string, level: string) => {
+        notifications.push({ message, level });
+      },
+    },
+    sessionManager: {
+      getSessionFile: () => "/tmp/source.jsonl",
+    },
+    switchSession: () => Promise.resolve({ cancelled: false }),
+    ...overrides,
+  });
+
+  const flushTimers = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  const makeSwitchSession = (
+    sendCalls: string[],
+    notifications: Array<{ message: string; level: string }>,
+  ) =>
+  (
+    _path: string,
+    options?: {
+      withSession?: (
+        ctx: {
+          hasUI: boolean;
+          ui: { notify: (message: string, level: string) => void };
+          sendUserMessage: (message: string) => Promise<void>;
+        },
+      ) => Promise<void>;
+    },
+  ) => {
+    if (options?.withSession) {
+      return options.withSession({
+        hasUI: true,
+        ui: {
+          notify: (message: string, level: string) => {
+            notifications.push({ message, level });
+          },
+        },
+        sendUserMessage: (message: string) => {
+          sendCalls.push(message);
+          return Promise.resolve();
+        },
+      }).then(() => ({ cancelled: false }));
+    }
+    return Promise.resolve({ cancelled: false });
+  };
+
+  return {
+    commands,
+    tools,
+    sendCalls,
+    notifications,
+    makeCtx,
+    makeSwitchSession,
+    emit,
+    flushTimers,
+    setIdle: (value: boolean) => {
+      idle = value;
+    },
+  };
+}
+
+Deno.test("resolveWorkspacePath resolves relative paths from cwd", () => {
+  const root = makeTempDir();
+  const nested = join(root, "nested");
+  mkdirSync(nested);
+  assertEquals(
+    resolveWorkspacePath("nested", root),
+    resolveWorkspacePath(nested, root),
+  );
+});
+
+Deno.test("resolveWorkspacePath rejects missing paths", () => {
+  const root = makeTempDir();
+  assertThrows(
+    () => resolveWorkspacePath(join(root, "missing"), root),
+    WorkspacePathError,
+    "Directory not found",
+  );
+});
+
+Deno.test("resolveWorkspacePath rejects files", () => {
+  const root = makeTempDir();
+  const filePath = join(root, "file.txt");
+  writeFileSync(filePath, "x");
+  assertThrows(
+    () => resolveWorkspacePath(filePath, root),
+    WorkspacePathError,
+    "Not a directory",
+  );
+});
+
+Deno.test("resolveWorkspacePath rejects empty input", () => {
+  const root = makeTempDir();
+  assertThrows(
+    () => resolveWorkspacePath("  ", root),
+    WorkspacePathError,
+    "Path is required",
+  );
+});
+
+Deno.test("switchWorkspaceSession no-ops when target equals current cwd", async () => {
+  const root = makeTempDir();
+  let forkCalled = false;
+  const outcome = await switchWorkspaceSession(
+    {
+      forkFrom: () => {
+        forkCalled = true;
+        throw new Error("forkFrom should not run");
+      },
+      switchSession: () => Promise.resolve({ cancelled: false }),
+      getSessionFile: () => "/tmp/source.jsonl",
+      getCwd: () => root,
+    },
+    root,
+  );
+  assertEquals(outcome.switched, false);
+  assertEquals(outcome.targetPath, resolveWorkspacePath(".", root));
+  assertEquals(forkCalled, false);
+});
+
+Deno.test("switchWorkspaceSession requires a persisted source session", async () => {
+  const source = makeTempDir();
+  const target = makeTempDir();
+  await assertRejects(
+    () =>
+      switchWorkspaceSession(
+        {
+          forkFrom: SessionManager.forkFrom,
+          switchSession: () => Promise.resolve({ cancelled: false }),
+          getSessionFile: () => undefined,
+          getCwd: () => source,
+        },
+        target,
+      ),
+    WorkspacePathError,
+    "not persisted",
+  );
+});
+
+Deno.test("switchWorkspaceSession forks into target cwd and preserves history", async () => {
+  const sourceCwd = makeTempDir();
+  const targetCwd = makeTempDir();
+  const sessionDir = join(sourceCwd, "sessions");
+
+  const source = SessionManager.create(sourceCwd, sessionDir);
+  persistSessionHistory(source);
+  const sourceFile = source.getSessionFile();
+  if (!sourceFile) throw new Error("expected persisted source session");
+
+  let switchedTo: string | undefined;
+  const freshNotifications: Array<{ message: string; level: string }> = [];
+  const continueMessages: string[] = [];
+
+  const outcome = await switchWorkspaceSession(
+    {
+      forkFrom: SessionManager.forkFrom,
+      switchSession: async (sessionPath, options) => {
+        switchedTo = sessionPath;
+        if (options?.withSession) {
+          await options.withSession({
+            hasUI: true,
+            ui: {
+              notify: (message: string, level: string) => {
+                freshNotifications.push({ message, level });
+              },
+            },
+            sendUserMessage: (message: string) => {
+              continueMessages.push(message);
+              return Promise.resolve();
+            },
+          } as never);
+        }
+        return { cancelled: false };
+      },
+      getSessionFile: () => sourceFile,
+      getCwd: () => sourceCwd,
+    },
+    targetCwd,
+    { autoContinue: true },
+  );
+
+  assertEquals(outcome.switched, true);
+  assertEquals(outcome.targetPath, resolveWorkspacePath(targetCwd, sourceCwd));
+  assertEquals(continueMessages.length, 1);
+  assertEquals(freshNotifications, [{
+    message: `Switched to ${resolveWorkspacePath(targetCwd, sourceCwd)}`,
+    level: "info",
+  }]);
+  if (!outcome.sessionFile) throw new Error("expected forked session file");
+  assertEquals(switchedTo, outcome.sessionFile);
+
+  const forked = SessionManager.open(outcome.sessionFile, undefined, targetCwd);
+  assertEquals(forked.getCwd(), targetCwd);
+  assertEquals(forked.getEntries().length, source.getEntries().length);
+});
+
+Deno.test("switchWorkspaceSession uses forkFrom with source session file and target cwd", async () => {
+  const sourceCwd = await mkdtemp(join(tmpdir(), "pi-ws-source-"));
+  const targetCwd = await mkdtemp(join(tmpdir(), "pi-ws-target-"));
+  const sessionDir = join(sourceCwd, "sessions");
+  const source = SessionManager.create(sourceCwd, sessionDir);
+  persistSessionHistory(source);
+  const sourceFile = source.getSessionFile();
+  if (!sourceFile) throw new Error("expected source session");
+
+  let forkArgs: { sourcePath?: string; targetCwd?: string } = {};
+  await switchWorkspaceSession(
+    {
+      forkFrom: (sourcePath, target) => {
+        forkArgs = { sourcePath, targetCwd: target };
+        return SessionManager.forkFrom(
+          sourcePath,
+          target,
+          join(target, "sessions"),
+        );
+      },
+      switchSession: () => Promise.resolve({ cancelled: false }),
+      getSessionFile: () => sourceFile,
+      getCwd: () => sourceCwd,
+    },
+    targetCwd,
+  );
+
+  assertEquals(forkArgs.sourcePath, sourceFile);
+  assertEquals(forkArgs.targetCwd, resolveWorkspacePath(targetCwd, sourceCwd));
+});
+
+Deno.test("switchWorkspaceSession removes fork file when switch is cancelled", async () => {
+  const sourceCwd = await mkdtemp(join(tmpdir(), "pi-ws-cancel-"));
+  const targetCwd = await mkdtemp(join(tmpdir(), "pi-ws-cancel-target-"));
+  const sessionDir = join(sourceCwd, "sessions");
+  const source = SessionManager.create(sourceCwd, sessionDir);
+  persistSessionHistory(source);
+  const sourceFile = source.getSessionFile();
+  if (!sourceFile) throw new Error("expected source session");
+
+  let forkSessionFile: string | undefined;
+  await assertRejects(
+    () =>
+      switchWorkspaceSession(
+        {
+          forkFrom: (sourcePath, target) => {
+            const forked = SessionManager.forkFrom(
+              sourcePath,
+              target,
+              join(target, "sessions"),
+            );
+            forkSessionFile = forked.getSessionFile();
+            return forked;
+          },
+          switchSession: () => Promise.resolve({ cancelled: true }),
+          getSessionFile: () => sourceFile,
+          getCwd: () => sourceCwd,
+        },
+        targetCwd,
+        { autoContinue: true },
+      ),
+    WorkspacePathError,
+    "cancelled",
+  );
+
+  if (!forkSessionFile) throw new Error("expected fork session file");
+  assertEquals(existsSync(forkSessionFile), false);
+});
+
+Deno.test("switch_workspace_cwd stores pending target and terminates without sendUserMessage", async () => {
+  const root = makeTempDir();
+  const target = join(root, "dest");
+  mkdirSync(target);
+
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  const resolved = resolveWorkspacePath(target, root);
+  const result = await execute(
+    "call-1",
+    { path: "dest" },
+    undefined,
+    undefined,
+    {
+      cwd: root,
+      sessionManager: { getSessionFile: () => "/tmp/source.jsonl" },
+    },
+  );
+
+  assertEquals(fake.sendCalls.length, 0);
+  assertEquals(result.details, { path: resolved, scheduled: true });
+  assertEquals(result.terminate, true);
+});
+
+Deno.test("switch_workspace_cwd dispatches continue command after agent_settled when idle", async () => {
+  const root = makeTempDir();
+  const target = join(root, "dest");
+  mkdirSync(target);
+
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  const resolved = resolveWorkspacePath(target, root);
+  await execute(
+    "call-1",
+    { path: "dest" },
+    undefined,
+    undefined,
+    {
+      cwd: root,
+      sessionManager: { getSessionFile: () => "/tmp/source.jsonl" },
+    },
+  );
+
+  assertEquals(fake.sendCalls.length, 0);
+  fake.emit("agent_settled", {}, fake.makeCtx());
+  await fake.flushTimers();
+
+  assertEquals(fake.sendCalls, [{
+    content: `/${WORKSPACE_CD_CONTINUE_COMMAND} ${
+      encodeURIComponent(resolved)
+    }`,
+    options: { expandPromptTemplates: true },
+  }]);
+});
+
+Deno.test("switch_workspace_cwd rejects non-persisted session before scheduling", () => {
+  const root = makeTempDir();
+  const target = join(root, "dest");
+  mkdirSync(target);
+
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  assertThrows(
+    () =>
+      execute(
+        "call-1",
+        { path: "dest" },
+        undefined,
+        undefined,
+        {
+          cwd: root,
+          sessionManager: { getSessionFile: () => undefined },
+        },
+      ),
+    WorkspacePathError,
+    "not persisted",
+  );
+
+  assertEquals(fake.sendCalls.length, 0);
+  fake.emit("agent_settled", {}, fake.makeCtx());
+});
+
+Deno.test("session_shutdown clears pending workspace-cd dispatch", async () => {
+  const root = makeTempDir();
+  const target = join(root, "dest");
+  mkdirSync(target);
+
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  await execute(
+    "call-1",
+    { path: "dest" },
+    undefined,
+    undefined,
+    {
+      cwd: root,
+      sessionManager: { getSessionFile: () => "/tmp/source.jsonl" },
+    },
+  );
+
+  fake.emit("agent_settled", {}, fake.makeCtx());
+  fake.emit("session_shutdown", {}, fake.makeCtx());
+  await fake.flushTimers();
+
+  assertEquals(fake.sendCalls.length, 0);
+});
+
+Deno.test("switch_workspace_cwd throws WorkspacePathError for invalid path", () => {
+  const root = makeTempDir();
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  assertThrows(
+    () =>
+      execute(
+        "call-1",
+        { path: join(root, "missing") },
+        undefined,
+        undefined,
+        { cwd: root },
+      ),
+    WorkspacePathError,
+  );
+  assertEquals(fake.sendCalls.length, 0);
+});
+
+Deno.test("switch_workspace_cwd skips queue when already in target cwd", async () => {
+  const root = makeTempDir();
+  const fake = createFakePi(root);
+  const execute = fake.tools.get("switch_workspace_cwd");
+  if (!execute) throw new Error("tool not registered");
+
+  const result = await execute("call-1", { path: "." }, undefined, undefined, {
+    cwd: root,
+  });
+
+  assertEquals(fake.sendCalls.length, 0);
+  assertEquals((result.details as { switched: boolean }).switched, false);
+  assertEquals(result.terminate, undefined);
+});
+
+Deno.test("/workspace-cd-continue throws on cancelled switch without continuation", async () => {
+  const source = makeTempDir();
+  const target = makeTempDir();
+  const sessionDir = join(source, "sessions");
+  const sourceSession = SessionManager.create(source, sessionDir);
+  persistSessionHistory(sourceSession);
+  const sourceFile = sourceSession.getSessionFile();
+  if (!sourceFile) throw new Error("expected source session");
+
+  const fake = createFakePi(source);
+  const continueHandler = fake.commands.get(WORKSPACE_CD_CONTINUE_COMMAND);
+  if (!continueHandler) throw new Error("continue command not registered");
+
+  const freshSendCalls: string[] = [];
+  const resolvedTarget = resolveWorkspacePath(target, source);
+  await assertRejects(
+    () =>
+      continueHandler(encodeURIComponent(resolvedTarget), {
+        ...fake.makeCtx(),
+        sessionManager: { getSessionFile: () => sourceFile },
+        switchSession: () => Promise.resolve({ cancelled: true }),
+      }),
+    WorkspacePathError,
+    "cancelled",
+  );
+
+  assertEquals(freshSendCalls.length, 0);
+});
+
+Deno.test("/workspace-cd-continue switches and sends continuation in fresh context", async () => {
+  const source = makeTempDir();
+  const target = makeTempDir();
+  const sessionDir = join(source, "sessions");
+  const sourceSession = SessionManager.create(source, sessionDir);
+  persistSessionHistory(sourceSession);
+  const sourceFile = sourceSession.getSessionFile();
+  if (!sourceFile) throw new Error("expected source session");
+
+  const fake = createFakePi(source);
+  const continueHandler = fake.commands.get(WORKSPACE_CD_CONTINUE_COMMAND);
+  if (!continueHandler) throw new Error("continue command not registered");
+
+  const freshSendCalls: string[] = [];
+  const resolvedTarget = resolveWorkspacePath(target, source);
+  await continueHandler(encodeURIComponent(resolvedTarget), {
+    ...fake.makeCtx(),
+    sessionManager: { getSessionFile: () => sourceFile },
+    switchSession: fake.makeSwitchSession(freshSendCalls, fake.notifications),
+  });
+
+  assertEquals(freshSendCalls.length, 1);
+  assertEquals(
+    fake.notifications.some((n) =>
+      n.level === "info" && n.message === `Switched to ${resolvedTarget}`
+    ),
+    true,
+  );
+});
+
+Deno.test("/workspace-cd manual switch does not send continuation", async () => {
+  const source = makeTempDir();
+  const target = makeTempDir();
+  const sessionDir = join(source, "sessions");
+  const sourceSession = SessionManager.create(source, sessionDir);
+  persistSessionHistory(sourceSession);
+  const sourceFile = sourceSession.getSessionFile();
+  if (!sourceFile) throw new Error("expected source session");
+
+  const fake = createFakePi(source);
+  const handler = fake.commands.get(WORKSPACE_CD_COMMAND);
+  if (!handler) throw new Error("command not registered");
+
+  const resolvedTarget = resolveWorkspacePath(target, source);
+  const freshSendCalls: string[] = [];
+  await handler(resolvedTarget, {
+    ...fake.makeCtx(),
+    sessionManager: { getSessionFile: () => sourceFile },
+    switchSession: fake.makeSwitchSession(freshSendCalls, fake.notifications),
+  });
+
+  assertEquals(freshSendCalls.length, 0);
+  assertEquals(
+    fake.notifications.some((n) =>
+      n.level === "info" && n.message === `Switched to ${resolvedTarget}`
+    ),
+    true,
+  );
+});
+
+Deno.test("/workspace-cd-continue without path fails clearly", async () => {
+  const root = makeTempDir();
+  const fake = createFakePi(root);
+  const handler = fake.commands.get(WORKSPACE_CD_CONTINUE_COMMAND);
+  if (!handler) throw new Error("continue command not registered");
+
+  await assertRejects(
+    () => handler("", fake.makeCtx()),
+    WorkspacePathError,
+  );
+  assertEquals(fake.notifications.some((n) => n.level === "error"), true);
+});
+
+Deno.test("/workspace-cd rejects missing args with usage notification", async () => {
+  const root = makeTempDir();
+  const fake = createFakePi(root);
+  const handler = fake.commands.get(WORKSPACE_CD_COMMAND);
+  if (!handler) throw new Error("command not registered");
+
+  await handler("", fake.makeCtx());
+
+  assertEquals(fake.notifications, [{
+    message: "Usage: /workspace-cd <path>",
+    level: "warning",
+  }]);
+});

--- a/skills/jj-workspace/SKILL.md
+++ b/skills/jj-workspace/SKILL.md
@@ -20,7 +20,11 @@ jj コマンドは必ず `JJ_EDITOR=true` を付けて実行する（エディ�
 2. **workspace 名とパスを決める**: 依頼内容から短い名前を自動生成する（ユーザー指定があればそれを使う）。パスはリポジトリの隣に `<repo>-<用途>` で作る。CRM / Sentry は「6. CRM 固有」の命名に従う。
 3. **workspace を切る**: 特別な指定が無ければそのリポの trunk（多くの場合 `-r main@origin`。CRM は必須）から切る。現在の作業の続きなら `-r` 省略（=`@`、`jjw` デフォルトと同じ）。
 4. **セットアップを実行**: 「2. 作成直後のセットアップ」を必ず行う。リポ固有の追加手順があれば続けて実行する。
-5. **その workspace ディレクトリで作業する**。
+5. **cmux タスク名を同期**（Pi / cmux 経由のセッションのみ）: workspace 名やタスク内容が確定したら、**最終 tool の前に** cmux の `custom_title` / description を同期する。Pi セッション名のライフサイクル同期（旧 run の settle 後）は agent が待たない。
+6. **Pi agent: 新 cwd へセッション切替**（下記「Pi agent: セッション cwd の切り替え」）。**`switch_workspace_cwd` はこのセッションで最後に呼ぶ tool**。旧セッションではそれ以降 tool を呼ばない。
+7. **その workspace ディレクトリで作業する**（Pi では切替先セッションが自動継続する）。
+
+人間が `jjw` で切った場合は 5–6 を省略し、作成後に `cd` して作業する（従来どおり）。**Pi agent は shell の `cd` では cwd を変えられない** — 必ず下記「Pi agent: セッション cwd の切り替え」の `switch_workspace_cwd` を使う。
 
 迷ったら「まず workspace を切る」。default で直接編集を進めるのは、ユーザーが明示的にそれを求めた場合だけにする。
 
@@ -55,7 +59,16 @@ jjw
 - `-r <rev>`: どのリビジョンの上に空コミットを作るか。省略時は `@`（`jjw` と同じ）。trunk から切るならそのリポの trunk。
 - `<path>`: 作業ディレクトリ。**リポジトリの隣に `<repo>-<用途>`**（CRM は `crm-<用途>`）。
 
-作成後、その新しいディレクトリに `cd` して作業する。各 workspace は独立した working-copy commit (`@`) を持つので、ビルド成果物や作業中の変更は混ざらない。
+作成後、人間はその新しいディレクトリに `cd` して作業する。Pi agent は shell の `cd` ではなく、次節のセッション切り替えを使う。各 workspace は独立した working-copy commit (`@`) を持つので、ビルド成果物や作業中の変更は混ざらない。
+
+## Pi agent: セッション cwd の切り替え
+
+Pi 上で workspace を切った agent は、shell の `cd` では Pi の cwd を変えられない。**セットアップと cmux `custom_title`/description 同期がすべて終わったら、最後の tool として 1 回だけ `switch_workspace_cwd` を destination パスで呼ぶ。**
+
+- **順序**: `jj workspace add` → セットアップ（`.env*` symlink / direnv / リポ固有）→ cmux `custom_title`/description 同期 → **`switch_workspace_cwd(path)`**（最終 tool）
+- **この tool の後に旧セッションで他の tool を呼ばない。** 拡張は persisted session であることを確認したうえで destination を extension-local に保持し、`terminate: true` で現在の agent run を止める。旧 run が `agent_settled` したあと idle になった時点で、内部コマンド `/workspace-cd-continue <encoded-path>` を `expandPromptTemplates: true` で dispatch する（follow-up キューではない）。そのコマンドがセッションを fork/switch し、切替先セッションで短い継続メッセージにより元タスクを自動再開する。Pi セッション名の同期は旧 run settle 後に起きるため、最終 tool 前に待たない。
+- **手動切替**（ユーザー向け）: `/workspace-cd <path>` — 同じ fork/switch だが自動継続はしない。
+- **人間の `jjw` フローは変更なし**（fish で切って `cd` するだけ）。
 
 ## 2. 作成直後のセットアップ（必須・汎用）
 


### PR DESCRIPTION
## 概要
- `jj workspace add`後も実行中Piのcwdが変わらず、旧workspaceで作業を続ける問題を解消します
- 会話履歴を保持したsession fork/switchにより、新workspaceで元タスクを自動継続します
- 非永続sessionや切替キャンセルを安全に扱います

## 変更内容

```mermaid
flowchart LR
  create[jj workspace作成・セットアップ] --> tool[switch_workspace_cwd]
  tool --> settled[agent_settled / idle]
  settled --> fork[sessionを新cwdへfork]
  fork --> resume[切替先で元タスクを自動継続]
```

- `switch_workspace_cwd`と手動`/workspace-cd`を追加
- destinationのcanonical path検証とpersisted sessionの事前確認を追加
- `agent_settled`後に内部commandをdispatchし、stale contextを避けてsessionを切替
- cancellation時に生成したfork session fileをbest-effortでcleanup
- `jj-workspace` skillとPi READMEへ運用手順を追加

## 確認
- [x] `deno fmt --check pi/agent/extensions/workspace-cd.ts pi/agent/tests/workspace-cd.test.ts`
- [x] `deno lint pi/agent/extensions/workspace-cd.ts pi/agent/tests/workspace-cd.test.ts`
- [x] `deno check pi/agent/extensions/workspace-cd.ts pi/agent/tests/workspace-cd.test.ts`
- [x] `deno test -A pi/agent/tests/workspace-cd.test.ts`（20 passed）
- [x] `deno test -A pi/agent/tests`（95 passed）
