### PR TITLE
差分レビューをHunkへ統一しcloudflaredをDevbox管理する

### DIFF
--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -25,7 +25,6 @@
     "bun@latest",
     "temurin-bin-21@latest",
     "terraform@latest",
-    "difftastic@latest",
     "vscode-langservers-extracted@latest",
     "yaml-language-server@latest",
     "tailwindcss-language-server@latest",
@@ -53,7 +52,8 @@
     "taplo@latest",
     "github:yusukebe/ax",
     "hunk@latest",
-    "rsgain@latest"
+    "rsgain@latest",
+    "cloudflared@latest"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",

--- a/gitconfig
+++ b/gitconfig
@@ -7,8 +7,6 @@
 	ui = true
 [ghq]
 	root = ~/ghq
-[diff]
-	external = difft
 [merge]
 	tool = nvimdiff
 [difftool "nvimdiff"]
@@ -21,6 +19,7 @@
 	rebase = false
 [core]
 	autocrlf = input
+	pager = hunk pager
 [alias]
 	log = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative
 	lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative

--- a/hunk/config.toml
+++ b/hunk/config.toml
@@ -1,0 +1,1 @@
+watch = true

--- a/jjconfig.toml
+++ b/jjconfig.toml
@@ -7,14 +7,12 @@ email = "me@rrrr.dev"
 [ui]
 editor = "nvim"
 default-command = "log"
-pager = "less -FRX"
+pager = ["hunk", "pager"]
 diff-editor = ["nvim", "-d", "$left", "$right"]
-diff-formatter = ["difft", "--color=always", "$left", "$right"]
+diff-formatter = ":git"
 
 [aliases]
 current = ["log", "-r", "@ | @-"]
-diffn = ["diff", "--git", "--config=ui.pager=hunk pager --line-numbers"]
-diffs = ["diff", "--git", "--config=ui.pager=hunk pager --mode split"]
 
 [remotes.origin]
 auto-track-bookmarks = "glob:*"

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -35,6 +35,6 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.84.2",
+  "lastChangelogVersion": "0.84.3",
   "packages": []
 }

--- a/scripts/build_env/setup_fish.sh
+++ b/scripts/build_env/setup_fish.sh
@@ -129,6 +129,12 @@ create_symlink $BASE_DIR/jjconfig.toml ~/.config/jj/config.toml "jujutsu config"
 
 echo ""
 
+# Hunk設定ファイル
+echo "Setting up Hunk configuration..."
+create_symlink $BASE_DIR/hunk/config.toml ~/.config/hunk/config.toml "Hunk config"
+
+echo ""
+
 # cmux設定ファイル
 echo "Setting up cmux configuration..."
 create_symlink $BASE_DIR/cmux ~/.config/cmux "cmux configuration"


### PR DESCRIPTION
## 概要
- 通常の差分確認と対話レビューをHunkへ統一します
- cloudflaredをDevbox globalの管理対象に追加します
- Hunkのwatchを既定化し、変更を自動再読み込みします

## 変更内容
- jjとGitのpagerをHunkへ切り替え、difftasticを削除
- `hunk/config.toml`を追加し、セットアップ時にglobal configへsymlink
- Piのchangelog表示状態を0.84.3へ更新

## 確認
- [x] `jq -e . devbox/devbox.json`
- [x] `taplo check jjconfig.toml hunk/config.toml`
- [x] `fish --no-execute scripts/build_env/setup_fish.sh`
- [x] `deno test -A --quiet pi/agent/tests/`（95件成功）
- [x] Hunk 0.17.3 / cloudflared 2026.8.2 のDevbox導入確認
- [ ] `./scripts/run_tests.sh` の完走（現環境ではDeno権限指定とmacOS Bashの`mapfile`不足により未完了）