### PR TITLE
Obsidian VaultをCLIから同期できるようにする

### DIFF
--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -54,7 +54,8 @@
     "github:yusukebe/ax",
     "hunk@latest",
     "rsgain@latest",
-    "cloudflared@latest"
+    "cloudflared@latest",
+    "obsidian-headless@0.0.14"
   ],
   "env": {
     "PNPM_HOME":         "$HOME/.local/share/pnpm",


### PR DESCRIPTION
## 概要
- Obsidian Vaultをheadless環境から同期・操作できるようにします
- `obsidian-headless`をdevbox globalの再現可能なパッケージ構成へ追加します

## 確認
- [x] `devbox/devbox.json`を`jq empty`で検証
- [x] `ob --version`が`0.0.14`を返すことを確認
- [x] `devbox global list`に`obsidian-headless@0.0.14`が含まれることを確認
