### PR TITLE
Pi 0.84.4のchangelog確認状態を反映する

### DIFF
--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -35,6 +35,6 @@
   "extensions": [
     "extensions/*.ts"
   ],
-  "lastChangelogVersion": "0.84.3",
+  "lastChangelogVersion": "0.84.4",
   "packages": []
 }


### PR DESCRIPTION
## 概要
- Piの確認済みchangelogバージョンを、現在利用中の`0.84.4`へ更新します
- 環境再構築後も同じ確認状態を引き継げるようにします

## 確認
- [x] `pi/agent/settings.json`を`jq empty`で検証
- [x] `lastChangelogVersion`と`pi --version`がともに`0.84.4`であることを確認
