### PR TITLE
Pi と PATH で Homebrew ではなく devbox の bash を使う

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -107,6 +107,11 @@ switch (uname)
         if test -f /opt/homebrew/bin/brew
             eval (/opt/homebrew/bin/brew shellenv)
         end
+        # brew が PATH 先頭になるので、devbox 管理の bash 等を優先し直す
+        set -l devbox_bin "$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/bin"
+        if test -d $devbox_bin
+            fish_add_path --move --path $devbox_bin
+        end
     case Linux
         # Linux用の設定
         set -gx RUBY_CONFIGURE_OPTS "--with-openssl-dir=/usr"

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -16,6 +16,7 @@
     "sakana-ai-console/fugu-ultra:high"
   ],
   "theme": "dark",
+  "shellPath": "~/.local/share/devbox/global/default/.devbox/nix/profile/default/bin/bash",
   "defaultProjectTrust": "ask",
   "enableInstallTelemetry": false,
   "compaction": {

--- a/skills/parallel-review/SKILL.md
+++ b/skills/parallel-review/SKILL.md
@@ -9,7 +9,7 @@ description: 隔離済み Pi reviewer を3段階レベル（1=簡単/2=標準/3=
 
 ## 実行要件
 
-`run_pi_review.sh` は **Bash 5 以上**が必要。devbox の `bash@latest` がそれを供給する。`devbox global install` でインストールされ、PATH 上で Bash 5+ が先に解決される。macOS 付属の Bash 3.2 など古い Bash では、runner は `run_pi_review.sh requires Bash 5 or newer` と明示して nonzero で停止する。
+`run_pi_review.sh` は **Bash 5 以上**が必要。供給源は devbox の `bash@latest`（`devbox global install`）。Pi の bash ツールは未設定だと macOS の `/bin/bash`（3.2）を直呼びするので、`~/.pi/agent/settings.json` の `shellPath` を devbox profile の bash に固定する。Homebrew の bash は使わない。`#!/usr/bin/env bash` は PATH 上で Homebrew より devbox を先に解決する。古い Bash では runner が `run_pi_review.sh requires Bash 5 or newer` と明示して nonzero で停止する。
 
 ## レベル（1/2/3）
 


### PR DESCRIPTION
## 概要
- Pi の bash ツールが macOS の `/bin/bash` 3.2 を直呼びし、`declare -A` などの Bash 5 構文が落ちていた
- 対話シェルでも `brew shellenv` が PATH 先頭を取るため、devbox の `bash@latest` より Homebrew bash が先に解決されていた

## 変更内容
```mermaid
flowchart LR
  piTool[Pi bash ツール] -->|未設定| macos["/bin/bash 3.2"]
  piTool -->|shellPath| devbox["devbox bash 5"]
  brew[brew shellenv] --> homebrew["Homebrew bash"]
  brew --> prepend[devbox bin を PATH 先頭へ戻す]
  prepend --> devbox
```
- `pi/agent/settings.json` の `shellPath` を devbox profile の bash に固定する
- `brew shellenv` のあと devbox bin を PATH 先頭に戻す
- `parallel-review` の実行要件を、Homebrew ではなく devbox bash を使う前提に更新する

## 確認
- [x] `jq` で `settings.json` が valid であること、`shellPath` が devbox profile を指すことを確認
- [x] fish 上で `brew shellenv` 後は Homebrew bash、devbox bin 再優先後は nix の Bash 5.3.15 になることを確認
- [ ] Pi 再起動後の `bash` ツールが devbox bash になること（このセッションでは未確認）