### PR TITLE
GPT-5.6で長時間セッションのcompact頻度を減らす

### DIFF
--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -1,5 +1,15 @@
 {
   "providers": {
+    "openai-codex": {
+      "modelOverrides": {
+        "gpt-5.6-sol": {
+          "contextWindow": 372000
+        },
+        "gpt-5.6-terra": {
+          "contextWindow": 372000
+        }
+      }
+    },
     "sakana-ai-console": {
       "name": "Sakana AI Console",
       "baseUrl": "https://api.sakana.ai/v1",


### PR DESCRIPTION
## 概要
- 長時間のPiセッションで自動compactが発生する頻度を抑える
- `gpt-5.6-sol` と `gpt-5.6-terra` の `contextWindow` をCodex backendの上限である372Kへ拡張する
- Fugu系の設定は変更しない

## 確認
- [x] `jq empty pi/agent/models.json`
- [x] `pi --list-models` でSol/Terraが372Kとして表示されることを確認