### PR TITLE
Pi とスキルの GPT 設定を GPT-6 Astra に統一する

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.6-sol"
+model = "gpt-6-astra"
 model_reasoning_effort = "medium"
 model_provider = "openai"
 personality = "pragmatic"

--- a/codex/skills/codex-review/SKILL.md
+++ b/codex/skills/codex-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-review
-description: Pi headless（OpenAI Codex Terra）で120秒上限の単体コードレビューを実行する。「レビューして」だけなら parallel-review を優先する。
+description: Pi headless（OpenAI Codex）で120秒上限の単体コードレビューを実行する。「レビューして」だけなら parallel-review を優先する。
 metadata:
   target_agent: Codex
 ---

--- a/pi/README.md
+++ b/pi/README.md
@@ -92,9 +92,18 @@ reference **roles** defined in `pi/agent/model-roles.json`:
 Current roles: `review.codex`, `review.claude`, `review.fugu`, `review.grok`,
 `impl.cursor`, `research.xai`, `codex.default`.
 
-To move to a new model version, edit `model-roles.json` only (the role's model ID
-and the `enabledModels` list), then run `--apply`. Skills pick it up immediately
-because `run_pi_review.sh --role ROLE` resolves through the same catalog.
+To move to a new model version, update `model-roles.json` (role model IDs,
+`reviewLevels` tier models, role labels, and the `enabledModels` cycling list),
+then run `--apply` and `--check`. Skills pick it up immediately because
+`run_pi_review.sh --role ROLE` resolves through the same catalog.
+
+`enabledModels` controls Pi's Ctrl+P cycling choices (configured with
+`/scoped-models`); it is not an allowlist for `--model` or skill role resolution. Role and tier
+models live in `roles` and `reviewLevels`.
+
+If you previously added custom `modelOverrides` in `models.json` for an old GPT
+version, remove them when migrating; Pi's built-in catalog context window is
+authoritative and stale overrides are not synced by `--apply`.
 
 `--apply` / `--check` cover the config files that cannot expand variables:
 

--- a/pi/agent/model-roles.json
+++ b/pi/agent/model-roles.json
@@ -6,17 +6,15 @@
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
     "anthropic/claude-opus-5:max",
-    "openai-codex/gpt-5.6-sol:xhigh",
-    "openai-codex/gpt-5.6-sol:max",
-    "openai-codex/gpt-5.6-terra:high",
-    "openai-codex/gpt-5.6-terra:max",
+    "openai-codex/gpt-6-astra:xhigh",
+    "openai-codex/gpt-6-astra:max",
     "sakana-ai-console/fugu:high",
     "sakana-ai-console/fugu-ultra:high"
   ],
   "roles": {
     "review.codex": {
-      "pi": "openai-codex/gpt-5.6-terra:high",
-      "label": "Codex GPT-5.6 Terra High"
+      "pi": "openai-codex/gpt-6-astra:high",
+      "label": "Codex GPT-6 Astra High"
     },
     "review.claude": {
       "pi": "anthropic/claude-opus-5:high",
@@ -41,8 +39,8 @@
       "label": "Grok 4.6 (X Search research)"
     },
     "codex.default": {
-      "id": "gpt-5.6-sol",
-      "label": "Codex GPT-5.6 Sol"
+      "id": "gpt-6-astra",
+      "label": "Codex GPT-6 Astra"
     }
   },
   "reviewTimeouts": {
@@ -53,17 +51,17 @@
   "reviewLevels": {
     "1": [
       { "pi": "xai/grok-4.6" },
-      { "pi": "openai-codex/gpt-5.6-terra" },
+      { "pi": "openai-codex/gpt-6-astra:high" },
       { "pi": "anthropic/claude-sonnet-5:high" }
     ],
     "2": [
       { "pi": "xai/grok-4.6" },
-      { "pi": "openai-codex/gpt-5.6-sol:xhigh" },
+      { "pi": "openai-codex/gpt-6-astra:xhigh" },
       { "pi": "anthropic/claude-opus-5:high" }
     ],
     "3": [
       { "pi": "xai/grok-4.6" },
-      { "pi": "openai-codex/gpt-5.6-sol:max" },
+      { "pi": "openai-codex/gpt-6-astra:max" },
       { "pi": "anthropic/claude-opus-5:max" },
       { "pi": "sakana-ai-console/fugu-ultra:high" }
     ]

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -1,15 +1,5 @@
 {
   "providers": {
-    "openai-codex": {
-      "modelOverrides": {
-        "gpt-5.6-sol": {
-          "contextWindow": 372000
-        },
-        "gpt-5.6-terra": {
-          "contextWindow": 372000
-        }
-      }
-    },
     "sakana-ai-console": {
       "name": "Sakana AI Console",
       "baseUrl": "https://api.sakana.ai/v1",

--- a/pi/agent/settings.json
+++ b/pi/agent/settings.json
@@ -1,6 +1,6 @@
 {
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.6-sol",
+  "defaultModel": "gpt-6-astra",
   "defaultThinkingLevel": "xhigh",
   "enabledModels": [
     "xai/grok-4.6",
@@ -8,10 +8,8 @@
     "anthropic/claude-sonnet-5:max",
     "anthropic/claude-opus-5:high",
     "anthropic/claude-opus-5:max",
-    "openai-codex/gpt-5.6-sol:xhigh",
-    "openai-codex/gpt-5.6-sol:max",
-    "openai-codex/gpt-5.6-terra:high",
-    "openai-codex/gpt-5.6-terra:max",
+    "openai-codex/gpt-6-astra:xhigh",
+    "openai-codex/gpt-6-astra:max",
     "sakana-ai-console/fugu:high",
     "sakana-ai-console/fugu-ultra:high"
   ],

--- a/pi/agent/tests/resolve-model.bats
+++ b/pi/agent/tests/resolve-model.bats
@@ -278,3 +278,56 @@ EOF
 	[ "$status" -eq 0 ]
 	[ "${lines[0]}" = "$(printf 'xai/grok-4.6\t600\t900')" ]
 }
+
+@test "GPT roles, review tiers, and modelOverrides align with codex.default catalog model" {
+	# Arrange — integration against the tracked repo catalog
+	local real_catalog="$BATS_TEST_DIRNAME/../model-roles.json"
+	local real_models="$BATS_TEST_DIRNAME/../models.json"
+	local codex_id codex_pi_base codex_entry
+
+	codex_id=$(jq -r '.roles["codex.default"].id' "$real_catalog")
+	codex_pi_base="openai-codex/$codex_id"
+
+	# Assert — enabledModels cycling GPT entries share the codex.default base model
+	jq -e --arg base "$codex_pi_base" \
+		'[.enabledModels[] | select(startswith("openai-codex/"))] | length > 0 and all(startswith($base + ":"))' \
+		"$real_catalog" >/dev/null
+
+	# Assert — single reviewer review.codex uses high effort on the same base model
+	run env MODEL_ROLES_FILE="$real_catalog" "$RESOLVER" review.codex
+	[ "$status" -eq 0 ]
+	[ "$output" = "${codex_pi_base}:high" ]
+
+	run env MODEL_ROLES_FILE="$real_catalog" "$RESOLVER" --label review.codex
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"High"* ]]
+
+	# Assert — parallel-review GPT tiers use high / xhigh / max efforts
+	local level effort
+	for level in 1 2 3; do
+		case "$level" in
+		1) effort=high ;;
+		2) effort=xhigh ;;
+		3) effort=max ;;
+		esac
+		codex_entry=$(jq -r --arg lvl "$level" \
+			'[.reviewLevels[$lvl][] | select(.pi | startswith("openai-codex/")) | .pi][0]' \
+			"$real_catalog")
+		[ "$codex_entry" = "${codex_pi_base}:${effort}" ]
+	done
+
+	# Assert — codex.default resolves to the catalog id (no provider/thinking suffix)
+	run env MODEL_ROLES_FILE="$real_catalog" "$RESOLVER" codex.default
+	[ "$status" -eq 0 ]
+	[ "$output" = "$codex_id" ]
+
+	# Assert — stale custom OpenAI Codex overrides must not reference other GPT models
+	jq -e --arg model "$codex_id" \
+		'(.providers["openai-codex"].modelOverrides // {} | keys) |
+		 if length == 0 then true else all(. == $model) end' \
+		"$real_models" >/dev/null
+
+	# Assert — no legacy GPT-5 model ids remain in the role catalog
+	run jq -e '[.. | strings | select(test("gpt-5"))] | length == 0' "$real_catalog"
+	[ "$status" -eq 0 ]
+}

--- a/skills/parallel-review/SKILL.md
+++ b/skills/parallel-review/SKILL.md
@@ -15,9 +15,9 @@ description: 隔離済み Pi reviewer を3段階レベル（1=簡単/2=標準/3=
 
 レビューは3段階から選ぶ。指定なしは **2**。レベルごとに **精度（モデル/thinking）と timeout 予算**を選ぶ。timeout は patch サイズではなく `reviewTimeouts` の固定 per-level 予算（`resolve-model.sh --review-level N` で `pi<TAB>initial<TAB>retry` を引く）。
 
-- **1（簡単/速い）**: xai/grok-4.6 / gpt-5.6-terra / claude-sonnet-5:high。fugu なし。小さな変更の素早い確認向け。
-- **2（標準・既定）**: xai/grok-4.6 / gpt-5.6-sol:xhigh / claude-opus-5:high。fugu なし。
-- **3（deep/高精度）**: xai/grok-4.6 / gpt-5.6-sol:max / opus:max / fugu-ultra:high。重要変更・精査向け。Fugu は level 3 のみ。xAI Grok 4.6 は現在の Pi catalog で reasoning effort を固定できないため、全 level で同じモデル ID を使う。
+- **1（簡単/速い）**: xai/grok-4.6 / Codex high / claude-sonnet-5:high。fugu なし。小さな変更の素早い確認向け。
+- **2（標準・既定）**: xai/grok-4.6 / Codex xhigh / claude-opus-5:high。fugu なし。
+- **3（deep/高精度）**: xai/grok-4.6 / Codex max / opus:max / fugu-ultra:high。重要変更・精査向け。Fugu は level 3 のみ。xAI Grok 4.6 は現在の Pi catalog で reasoning effort を固定できないため、全 level で同じモデル ID を使う。Codex の tier 別 effort（high / xhigh / max）は `model-roles.json` の `reviewLevels` が正本。`resolve-model.sh --review-level N` で実際の Pi model id を確認する。
 
 **timeout 予算（固定）**:
 


### PR DESCRIPTION
## 概要
Pi の既定モデル・切替候補だけでなく、スキルのレビュー用 role と Codex の同期元も GPT-6 Astra に統一し、旧 GPT-5.6 が選択されたり同期で戻ったりする不整合を解消します。

## 変更内容
- Pi の既定モデルを GPT-6 Astra（xhigh）にし、GPT の切替候補を Astra の xhigh / max に限定
- 単体・軽量レビューを high、標準を xhigh、deep を max に統一。Codex CLI の model と同期元も更新
- 旧モデル用の context override を除去し、スキル説明・移行手順・カタログ整合性の回帰テストを更新
- 他社モデル、レビューの timeout、Cursor の実装用 role は維持。無関係なローカル設定変更は含めません

## 確認
- [x] resolver / review runner の Bats テスト：47 件成功
- [x] ShellCheck / shfmt / JSON / TOML 検証成功
- [x] PR に含める設定そのものに対して `resolve-model.sh --check` 成功
- [x] Pi のローカルカタログで Astra の high / xhigh / max 対応を確認
- 実 API を呼ぶスキル実行テストは未実施（review runner は隔離した fake Pi で検証）
