### PR TITLE
Obsidian Inbox スキルを復元してタスク追記を再び使えるようにする

### DIFF
--- a/skills/obsidian-inbox/SKILL.md
+++ b/skills/obsidian-inbox/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: obsidian-inbox
+description: Obsidian Vault の Inbox に Obsidian Tasks 形式のタスクを1行追記する。ユーザーが「Obsidian の Inbox に追加して」「これをタスクとしてメモして」「明日までのタスクを Inbox に入れて」など、Inbox への記録を明示したときに使う。相談や候補提示だけでは書き込まない。
+---
+
+# Obsidian Inbox
+
+ユーザーの Obsidian Vault Inbox へ、Obsidian Tasks 記法のタスクを **1行** 安全に追記する。ローカルファイルを変更するため、**Inbox への記録を明示した依頼がある場合だけ** 実行する。
+
+## いつ発動するか
+
+- 「Obsidian の Inbox に追加して」
+- 「これをタスクとしてメモして」
+- 「明日までのタスクを Inbox に入れて」
+
+次の場合は **書き込まない**:
+
+- タスク候補の提案・整理だけ
+- 「Inbox に入れた方がいいかも」など記録依頼が曖昧な相談
+
+## 対象ファイル
+
+既定: `$HOME/Documents/Vault/📥 Inbox.md`
+
+環境変数 `OBSIDIAN_INBOX_FILE` で上書き可能。helper の `--file` も使える。
+
+## 日付の解釈（agent 側）
+
+締切の自然言語は **agent が解釈** し、helper には ISO 形式 `YYYY-MM-DD` だけ渡す。
+
+| ユーザー表現 | 解釈 |
+|---|---|
+| 今日 | 実行時のローカル日付 |
+| 明日 | ローカル日付 + 1 日 |
+| N日後 | ローカル日付 + N 日 |
+
+**必ず** 実行時のローカル日付を `date` で確認してから絶対日付化する:
+
+```bash
+date +%Y-%m-%d
+date -v+1d +%Y-%m-%d   # macOS: 明日
+date -d tomorrow +%Y-%m-%d  # Linux: 明日
+```
+
+**勝手に決めない** 曖昧表現（例: なるはや、今週中、来週くらい）は、ユーザーに日付を確認してから helper を呼ぶ。
+
+## セクション振り分け
+
+| 条件 | セクション |
+|---|---|
+| 最優先（`--priority`） | `## 🚨 最優先` |
+| 最優先なし・期限あり（`--due`） | `## 📅 期限あり` |
+| どちらもなし | `## ⏳ 期限なし・あとで` |
+
+## 行フォーマット
+
+- 基本: `- [ ] <本文>`
+- 期限のみ: `- [ ] <本文> 📅 YYYY-MM-DD`
+- 最優先＋期限: `- [ ] <本文> 📅 YYYY-MM-DD ⏫`
+- 最優先のみ: `- [ ] <本文> ⏫`
+- URL / Markdown link は **本文側** に置き、Tasks metadata（`📅` `⏫`）は **行末**
+
+## 実行手順
+
+```bash
+SCRIPT="$HOME/.agents/skills/obsidian-inbox/scripts/add-task.sh"
+# またはリポジトリ内: skills/obsidian-inbox/scripts/add-task.sh
+
+# 期限なし
+bash "$SCRIPT" -- "タスク本文"
+
+# 期限あり（YYYY-MM-DD は agent が解決済み）
+bash "$SCRIPT" --due 2026-09-04 -- "タスク本文"
+
+# 最優先＋期限
+bash "$SCRIPT" --due 2026-09-04 --priority -- "タスク本文"
+
+# ファイル指定
+bash "$SCRIPT" --file "$OBSIDIAN_INBOX_FILE" -- "タスク本文"
+```
+
+## 完了報告
+
+1. helper の stdout（追加した完全な1行）を確認
+2. 対象ファイルの該当行または末尾付近を確認
+3. ユーザーへ **追記内容** と **解決済み日付**（あれば）を短く返す
+
+## 注意
+
+- 実 Vault をテスト用途で書き換えない
+- 本文に改行を含めない（複数行タスクは不可）
+- helper が非0終了したら内容を変えず、エラーをユーザーに伝える

--- a/skills/obsidian-inbox/scripts/add-task.sh
+++ b/skills/obsidian-inbox/scripts/add-task.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Append one Obsidian Tasks line to the Vault Inbox file.
+set -euo pipefail
+
+die() {
+	printf '%s\n' "$1" >&2
+	exit 1
+}
+
+usage() {
+	cat <<'EOF'
+Usage: add-task.sh [--file PATH] [--due YYYY-MM-DD] [--priority] -- TEXT...
+
+Append one Obsidian Tasks line to the Inbox file.
+Default file: OBSIDIAN_INBOX_FILE or $HOME/Documents/Vault/📥 Inbox.md
+EOF
+}
+
+validate_due_date() {
+	local due=$1
+
+	if [[ ! "$due" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+		die "invalid due date format (expected YYYY-MM-DD): $due"
+	fi
+
+	if date -j -f "%Y-%m-%d" "$due" "+%Y-%m-%d" >/dev/null 2>&1; then
+		[[ "$(date -j -f "%Y-%m-%d" "$due" "+%Y-%m-%d")" == "$due" ]] || die "invalid due date: $due"
+	elif date -d "$due" "+%Y-%m-%d" >/dev/null 2>&1; then
+		[[ "$(date -d "$due" "+%Y-%m-%d")" == "$due" ]] || die "invalid due date: $due"
+	else
+		die "invalid due date: $due"
+	fi
+}
+
+validate_task_text() {
+	local text=$1
+
+	if [[ -z "$text" ]]; then
+		die "task text must not be empty"
+	fi
+
+	if [[ "$text" == *$'\n'* || "$text" == *$'\r'* ]]; then
+		die "task text must not contain newlines"
+	fi
+}
+
+build_task_line() {
+	local text=$1
+	local due=${2:-}
+	local priority=${3:-0}
+
+	local line="- [ ] $text"
+
+	if [[ -n "$due" ]]; then
+		line+=" 📅 $due"
+	fi
+
+	if [[ "$priority" -eq 1 ]]; then
+		line+=" ⏫"
+	fi
+
+	printf '%s' "$line"
+}
+
+select_section_heading() {
+	local priority=$1
+	local due=$2
+
+	if [[ "$priority" -eq 1 ]]; then
+		printf '%s' '## 🚨 最優先'
+	elif [[ -n "$due" ]]; then
+		printf '%s' '## 📅 期限あり'
+	else
+		printf '%s' '## ⏳ 期限なし・あとで'
+	fi
+}
+
+insert_task_line() {
+	local inbox_file=$1
+	local section_heading=$2
+	local task_line=$3
+
+	local inbox_dir mode tmp
+	inbox_dir=$(dirname "$inbox_file")
+	tmp=$(mktemp "$inbox_dir/.obsidian-inbox.XXXXXX")
+	trap 'rm -f "$tmp"' RETURN EXIT
+
+	TASK_LINE=$task_line awk -v section="$section_heading" '
+		function flush_section() {
+			if (in_section && !inserted) {
+				print task
+				inserted = 1
+			}
+		}
+
+		BEGIN {
+			task = ENVIRON["TASK_LINE"]
+			in_section = 0
+			inserted = 0
+			found_section = 0
+		}
+
+		$0 == section {
+			found_section = 1
+			in_section = 1
+			print
+			next
+		}
+
+		in_section && /^## / {
+			flush_section()
+			in_section = 0
+			print
+			next
+		}
+
+		in_section && /^- \[ \][[:space:]]*$/ {
+			if (!inserted) {
+				print task
+				inserted = 1
+			}
+			print
+			next
+		}
+
+		{
+			print
+		}
+
+		END {
+			if (!found_section) {
+				exit 2
+			}
+			flush_section()
+			if (!inserted) {
+				exit 3
+			}
+		}
+	' "$inbox_file" >"$tmp" || {
+		local awk_status=$?
+		rm -f "$tmp"
+		trap - RETURN EXIT
+		case "$awk_status" in
+		2) die "target section heading not found: $section_heading" ;;
+		3) die "failed to insert task into section: $section_heading" ;;
+		*) die "failed to update inbox file: $inbox_file" ;;
+		esac
+	}
+
+	mode=$(stat -f '%Lp' "$inbox_file" 2>/dev/null || stat -c '%a' "$inbox_file")
+	chmod "$mode" "$tmp" || die "failed to preserve inbox file mode: $inbox_file"
+	mv "$tmp" "$inbox_file"
+	trap - RETURN EXIT
+
+	printf '%s\n' "$task_line"
+}
+
+main() {
+	local inbox_file=${OBSIDIAN_INBOX_FILE:-"$HOME/Documents/Vault/📥 Inbox.md"}
+	local due=""
+	local priority=0
+	local text=""
+	local saw_separator=0
+
+	while (($# > 0)); do
+		case "$1" in
+		-h | --help)
+			usage
+			exit 0
+			;;
+		--file)
+			shift
+			(($# > 0)) || die "missing value for --file"
+			inbox_file=$1
+			;;
+		--due)
+			shift
+			(($# > 0)) || die "missing value for --due"
+			due=$1
+			;;
+		--priority)
+			priority=1
+			;;
+		--)
+			saw_separator=1
+			shift
+			break
+			;;
+		-*)
+			die "unknown option: $1"
+			;;
+		*)
+			if [[ "$saw_separator" -eq 1 ]]; then
+				break
+			fi
+			die "unexpected argument: $1 (use -- before task text)"
+			;;
+		esac
+		shift
+	done
+
+	if [[ "$saw_separator" -eq 0 ]]; then
+		die "missing -- separator before task text"
+	fi
+
+	if (($# == 0)); then
+		die "task text must not be empty"
+	fi
+
+	text=$*
+	validate_task_text "$text"
+
+	if [[ -n "$due" ]]; then
+		validate_due_date "$due"
+	fi
+
+	[[ -f "$inbox_file" ]] || die "inbox file not found: $inbox_file"
+	[[ -r "$inbox_file" && -w "$inbox_file" ]] || die "inbox file is not readable/writable: $inbox_file"
+
+	local section_heading task_line
+	section_heading=$(select_section_heading "$priority" "$due")
+	task_line=$(build_task_line "$text" "$due" "$priority")
+	insert_task_line "$inbox_file" "$section_heading" "$task_line"
+}
+
+main "$@"

--- a/skills/obsidian-inbox/tests/add-task.bats
+++ b/skills/obsidian-inbox/tests/add-task.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+	TEST_ROOT="$BATS_TEST_TMPDIR/obsidian-inbox"
+	mkdir -p "$TEST_ROOT"
+	SCRIPT="$BATS_TEST_DIRNAME/../scripts/add-task.sh"
+	INBOX="$TEST_ROOT/Inbox.md"
+}
+
+make_inbox_fixture() {
+	cat >"$INBOX" <<'EOF'
+# 📥 Inbox
+
+## 🚨 最優先
+- [ ]
+
+## 📅 期限あり
+- [ ]
+
+## ⏳ 期限なし・あとで
+- [ ]
+EOF
+}
+
+make_inbox_without_placeholders() {
+	cat >"$INBOX" <<'EOF'
+# 📥 Inbox
+
+## 🚨 最優先
+
+## 📅 期限あり
+- [ ] existing due task 📅 2099-01-01
+
+## ⏳ 期限なし・あとで
+- [ ]
+EOF
+}
+
+make_inbox_missing_section() {
+	cat >"$INBOX" <<'EOF'
+# 📥 Inbox
+
+## 🚨 最優先
+- [ ]
+
+## ⏳ 期限なし・あとで
+- [ ]
+EOF
+}
+
+snapshot_inbox() {
+	cp "$INBOX" "$TEST_ROOT/inbox.snapshot"
+}
+
+inbox_unchanged() {
+	diff -u "$TEST_ROOT/inbox.snapshot" "$INBOX"
+}
+
+file_mode() {
+	stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+@test "due task is inserted before placeholder in due section with trailing metadata" {
+	# Arrange
+	make_inbox_fixture
+	local due="2099-06-15"
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" --due "$due" -- "Buy milk"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[[ "$output" == "- [ ] Buy milk 📅 $due" ]]
+	local section
+	section=$(awk '
+		/^## 📅 期限あり$/ { show=1; next }
+		show && /^## / { exit }
+		show { print }
+	' "$INBOX")
+	[[ "$section" == *"- [ ] Buy milk 📅 $due"* ]]
+	local first second
+	first=$(printf '%s\n' "$section" | sed -n '1p')
+	second=$(printf '%s\n' "$section" | sed -n '2p')
+	[[ "$first" == "- [ ] Buy milk 📅 $due" ]]
+	[[ "$second" == "- [ ]" || "$second" == "- [ ] " ]]
+}
+
+@test "task without due date goes to the no-deadline section" {
+	# Arrange
+	make_inbox_fixture
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" -- "Read release notes"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[[ "$output" == "- [ ] Read release notes" ]]
+	local section
+	section=$(awk '
+		/^## ⏳ 期限なし・あとで$/ { show=1; next }
+		show && /^## / { exit }
+		show { print }
+	' "$INBOX")
+	[[ "$section" == *"- [ ] Read release notes"* ]]
+	local first second
+	first=$(printf '%s\n' "$section" | sed -n '1p')
+	second=$(printf '%s\n' "$section" | sed -n '2p')
+	[[ "$first" == "- [ ] Read release notes" ]]
+	[[ "$second" == "- [ ]" || "$second" == "- [ ] " ]]
+}
+
+@test "priority task with due date goes to priority section with due and priority metadata" {
+	# Arrange
+	make_inbox_fixture
+	local due="2099-12-31"
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" --due "$due" --priority -- "Fix production bug"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[[ "$output" == "- [ ] Fix production bug 📅 $due ⏫" ]]
+	local section
+	section=$(awk '
+		/^## 🚨 最優先$/ { show=1; next }
+		show && /^## / { exit }
+		show { print }
+	' "$INBOX")
+	[[ "$section" == *"- [ ] Fix production bug 📅 $due ⏫"* ]]
+}
+
+@test "preserves literal backslash sequences in task text" {
+	# Arrange
+	make_inbox_fixture
+	local text='Keep literal \n and \t markers'
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" -- "$text"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[ "$output" = "- [ ] $text" ]
+	[ "$(rg -Fxc -- "- [ ] $text" "$INBOX")" -eq 1 ]
+}
+
+@test "preserves inbox file mode" {
+	# Arrange
+	make_inbox_fixture
+	chmod 640 "$INBOX"
+
+	# Act
+	run env TMPDIR="$TEST_ROOT/missing-tmp" bash "$SCRIPT" --file "$INBOX" -- "Keep file mode"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[ "$(file_mode "$INBOX")" = "640" ]
+}
+
+@test "inserts before next heading when placeholder is absent" {
+	# Arrange
+	make_inbox_without_placeholders
+	local due="2099-03-01"
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" --due "$due" -- "New due task"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[[ "$output" == "- [ ] New due task 📅 $due" ]]
+	local section
+	section=$(awk '
+		/^## 📅 期限あり$/ { show=1; next }
+		show && /^## / { exit }
+		show { print }
+	' "$INBOX")
+	[[ "$section" == *"- [ ] New due task 📅 $due"* ]]
+	[[ "$section" == *"- [ ] existing due task 📅 2099-01-01"* ]]
+}
+
+@test "invalid due date fails without modifying inbox" {
+	# Arrange
+	make_inbox_fixture
+	snapshot_inbox
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" --due "not-a-date" -- "Broken task"
+
+	# Assert
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"YYYY-MM-DD"* ]]
+	inbox_unchanged
+}
+
+@test "empty task text fails without modifying inbox" {
+	# Arrange
+	make_inbox_fixture
+	snapshot_inbox
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" -- ""
+
+	# Assert
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"empty"* || "$output" == *"text"* ]]
+	inbox_unchanged
+}
+
+@test "missing target section fails without modifying inbox" {
+	# Arrange
+	make_inbox_missing_section
+	snapshot_inbox
+
+	# Act
+	run bash "$SCRIPT" --file "$INBOX" --due "2099-01-01" -- "Needs due section"
+
+	# Assert
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"section"* || "$output" == *"heading"* ]]
+	inbox_unchanged
+}
+
+@test "OBSIDIAN_INBOX_FILE override is honored" {
+	# Arrange
+	local override="$TEST_ROOT/custom-inbox.md"
+	make_inbox_fixture
+	cp "$INBOX" "$override"
+	snapshot_inbox
+
+	# Act
+	run env OBSIDIAN_INBOX_FILE="$override" bash "$SCRIPT" -- "Override path task"
+
+	# Assert
+	[ "$status" -eq 0 ]
+	[[ "$output" == "- [ ] Override path task" ]]
+	rg -Fq -- "- [ ] Override path task" "$override"
+	inbox_unchanged
+}


### PR DESCRIPTION
## 概要
- 欠けていた共有 `obsidian-inbox` スキルを復元し、Obsidian Inbox へのタスク追記を再び利用できるようにします。
- 明示的な記録依頼と日付解釈のルールを定義し、期限・優先度に応じたセクションへ Obsidian Tasks 形式で追記します。
- 入力検証、ファイル権限の保持、不正入力時に元ファイルを変更しない動作をテストで確認します。

## 確認
- [x] `shellcheck skills/obsidian-inbox/scripts/add-task.sh skills/obsidian-inbox/tests/add-task.bats`
- [x] `shfmt -d skills/obsidian-inbox/scripts/add-task.sh skills/obsidian-inbox/tests/add-task.bats`
- [x] `bats skills/obsidian-inbox/tests/add-task.bats` — 全10テスト成功
- [ ] 実 Vault への書き込み検証（データ保護のため未実施）
